### PR TITLE
fix: normalize class module sources to stream form (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ with ExcelFile("workbook.xlsm") as wb:
     wb.save("out.xlsm")
 ```
 
+Class sources are accepted in any form: a bare body (the header is
+synthesized), a `.cls` file exported straight from the VBE (the
+`VERSION ... CLASS` preamble is stripped and the required
+`Attribute VB_Base` line is added automatically), or a full
+stream-form source.
+
 ---
 
 ## Edit your macros as files on disk (recommended workflow)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,24 @@ All notable changes to pyOpenVBA are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Class modules built from VBE-exported `.cls` sources now compile in
+  the host** (GitHub issue #1). `add_module(kind=VBAModuleKind.other)`,
+  `set_module`, and `push_modules` normalize class sources from
+  file-export form to stream form via the new
+  `pyopenvba.vba.normalize_class_source()`: a leading
+  `VERSION 1.0 CLASS` / `BEGIN` / `END` preamble is stripped, and
+  `Attribute VB_Base` is inserted after `VB_Name` when missing.  On
+  replacement of an existing module the prior header's `VB_Base` line is
+  preserved, so document-module host CLSIDs are never overwritten.
+  Previously a supplied header was written into the stream verbatim: a
+  missing `VB_Base` made Excel raise "Invalid procedure call or
+  argument" at the first `New` site, and a VERSION preamble in the
+  stream raised "Compile error: Expected: end of statement" (both
+  verified against live Excel, as is the fix).  Supersedes the 2.0.1
+  guidance that callers must supply the `VB_Base` line themselves.
+
 ## [3.0.0] - 2026-05-24
 
 ### Added

--- a/src/pyopenvba/excel.py
+++ b/src/pyopenvba/excel.py
@@ -30,11 +30,13 @@ from pyopenvba.vba import (
     compress,
     detect_signature,
     invalidate_vba_project_cache,
+    normalize_class_source,
     parse_vba_project,
     rebuild_module_stream,
     serialize_dir_stream,
     serialize_project_stream,
     serialize_projectwm,
+    split_attribute_header,
     write_back_modules,
 )
 
@@ -159,13 +161,26 @@ class ExcelFile:
         ``Sheet1``, ...) keep their host-binding ``Attribute VB_*`` lines.
         This mirrors the VBE UX where the user only types the body.
 
+        When the target is a class-kind module (``VBAModuleKind.other``),
+        a supplied full source is normalized from file-export form to
+        stream form first (``VERSION ... CLASS`` preamble stripped,
+        ``Attribute VB_Base`` preserved or restored), so ``.cls`` files
+        exported from the VBE are accepted as-is.
+
         Changes are not written to disk until :meth:`save` is called.
         """
-        from pyopenvba.vba import split_attribute_header
         project = self.vba_project()
         for m in project.modules:
             if m.name.casefold() == name.casefold():
                 supplied_header, _ = split_attribute_header(source)
+                if supplied_header and m.kind == VBAModuleKind.other:
+                    # Convert file-export form to stream form.  prior_header
+                    # keeps the module's existing VB_Base line (including
+                    # host CLSIDs on document modules, which share the
+                    # 0x0022 module kind with plain classes).
+                    prior = m.attribute_header or split_attribute_header(m.source)[0]
+                    source = normalize_class_source(source, prior_header=prior)
+                    supplied_header, _ = split_attribute_header(source)
                 if supplied_header:
                     # Full-source replacement — also refresh the cached header.
                     m.source = source
@@ -272,8 +287,18 @@ class ExcelFile:
                 continue
             raw = child.read_bytes().decode(encoding, errors="replace")
             text = raw.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
+            new_header = ""
+            if module.kind == VBAModuleKind.other and split_attribute_header(text)[0]:
+                # Class-kind files may be VBE exports (file-export form);
+                # convert to stream form, preserving the module's existing
+                # VB_Base line via prior_header.
+                prior = module.attribute_header or split_attribute_header(module.source)[0]
+                text = normalize_class_source(text, prior_header=prior)
+                new_header = split_attribute_header(text)[0]
             if module.source != text:
                 module.source = text
+                if new_header:
+                    module.attribute_header = new_header
                 module.dirty = True
             updated.append(module.name)
         return updated

--- a/src/pyopenvba/powerpoint.py
+++ b/src/pyopenvba/powerpoint.py
@@ -30,11 +30,13 @@ from pyopenvba.vba import (
     compress,
     detect_signature,
     invalidate_vba_project_cache,
+    normalize_class_source,
     parse_vba_project,
     rebuild_module_stream,
     serialize_dir_stream,
     serialize_project_stream,
     serialize_projectwm,
+    split_attribute_header,
     write_back_modules,
 )
 
@@ -145,13 +147,26 @@ class PowerPointFile:
         automatically re-prepended so host-bound modules keep their
         ``Attribute VB_*`` lines.
 
+        When the target is a class-kind module (``VBAModuleKind.other``),
+        a supplied full source is normalized from file-export form to
+        stream form first (``VERSION ... CLASS`` preamble stripped,
+        ``Attribute VB_Base`` preserved or restored), so ``.cls`` files
+        exported from the VBE are accepted as-is.
+
         Changes are not written to disk until :meth:`save` is called.
         """
-        from pyopenvba.vba import split_attribute_header
         project = self.vba_project()
         for m in project.modules:
             if m.name.casefold() == name.casefold():
                 supplied_header, _ = split_attribute_header(source)
+                if supplied_header and m.kind == VBAModuleKind.other:
+                    # Convert file-export form to stream form.  prior_header
+                    # keeps the module's existing VB_Base line (including
+                    # host CLSIDs on document modules, which share the
+                    # 0x0022 module kind with plain classes).
+                    prior = m.attribute_header or split_attribute_header(m.source)[0]
+                    source = normalize_class_source(source, prior_header=prior)
+                    supplied_header, _ = split_attribute_header(source)
                 if supplied_header:
                     m.source = source
                     m.attribute_header = supplied_header
@@ -250,8 +265,18 @@ class PowerPointFile:
                 continue
             raw = child.read_bytes().decode(encoding, errors="replace")
             text = raw.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
+            new_header = ""
+            if module.kind == VBAModuleKind.other and split_attribute_header(text)[0]:
+                # Class-kind files may be VBE exports (file-export form);
+                # convert to stream form, preserving the module's existing
+                # VB_Base line via prior_header.
+                prior = module.attribute_header or split_attribute_header(module.source)[0]
+                text = normalize_class_source(text, prior_header=prior)
+                new_header = split_attribute_header(text)[0]
             if module.source != text:
                 module.source = text
+                if new_header:
+                    module.attribute_header = new_header
                 module.dirty = True
             updated.append(module.name)
         return updated

--- a/src/pyopenvba/vba.py
+++ b/src/pyopenvba/vba.py
@@ -769,6 +769,11 @@ class VBAProject:
         header is synthesized if one is not provided, matching the VBE UX
         where the user only types the executable body.
 
+        For ``kind=other`` the source is normalized from file-export form
+        to stream form first (``VERSION ... CLASS`` preamble stripped,
+        ``Attribute VB_Base`` ensured), so ``.cls`` files exported from
+        the VBE are accepted as-is.  See :func:`normalize_class_source`.
+
         Raises ``ValueError`` if a module with that name already exists.
         """
         needle = name.casefold()
@@ -776,9 +781,12 @@ class VBAProject:
             raise ValueError(f"Module already exists: {name!r}")
 
         # Normalize header: parse out any caller-supplied header, otherwise
-        # synthesize a minimal standard-module header.  Other (class/document)
-        # modules must be provided with a full header by the caller — we do
-        # not invent class metadata or host bindings.
+        # synthesize a minimal standard-module header.  Class (kind=other)
+        # sources are first converted from file-export form to stream form;
+        # a bare body passes through unchanged and falls into the
+        # synthesize_class_header branch below.
+        if kind == VBAModuleKind.other:
+            source = normalize_class_source(source)
         existing_header, _body = split_attribute_header(source)
         if existing_header:
             header = existing_header
@@ -1039,6 +1047,95 @@ def synthesize_class_header(name: str) -> str:
         'Attribute VB_TemplateDerived = False\r\n'
         'Attribute VB_Customizable = False\r\n'
     )
+
+
+def normalize_class_source(source: str, *, prior_header: str = "") -> str:
+    """Convert a class module source from file-export form to stream form.
+
+    The VBE writes two different textual forms of a class module.  The
+    on-disk export (``.cls`` file) begins with a ``VERSION 1.0 CLASS`` /
+    ``BEGIN`` ... ``END`` preamble and carries no ``Attribute VB_Base``
+    line.  The form stored inside the module stream is the opposite: no
+    VERSION preamble, and the attribute block includes ``VB_Base``.
+    Writing export-form text into the stream produces a workbook that
+    opens cleanly but fails to compile: a missing ``VB_Base`` raises
+    "Invalid procedure call or argument" at the first ``New`` site, and
+    a VERSION preamble is parsed as class body text and raises
+    "Compile error: Expected: end of statement" (both verified against
+    live Excel; see GitHub issue #1).
+
+    Normalization steps:
+
+    1. Strip a leading ``VERSION ... CLASS`` preamble if present.
+    2. Ensure the attribute header carries a ``VB_Base`` line: a
+       supplied one is kept untouched; otherwise the ``VB_Base`` line
+       from ``prior_header`` (the module's existing stream header --
+       this preserves host CLSIDs when a document module's source is
+       replaced) is copied in; otherwise the universal class CLSID is
+       inserted directly after ``Attribute VB_Name``.
+
+    Idempotent: stream-form input is returned unchanged.  The input's
+    line endings are preserved -- an inserted line copies the terminator
+    of its anchor line.  Sources whose header has no ``VB_Name`` anchor
+    (already invalid as a stream) are returned with only step 1 applied.
+    """
+    if not source:
+        return source
+
+    # Step 1: strip the export-only VERSION preamble.  Mirrors the
+    # detection in split_attribute_header so the two functions always
+    # agree on where a header begins.
+    stripped = source
+    if stripped.startswith("VERSION ") and " CLASS" in stripped[:64]:
+        end_idx = stripped.find("\r\nEND\r\n")
+        if end_idx != -1:
+            stripped = stripped[end_idx + len("\r\nEND\r\n"):]
+        else:
+            end_idx = stripped.find("\nEND\n")
+            if end_idx != -1:
+                stripped = stripped[end_idx + len("\nEND\n"):]
+
+    header, body = split_attribute_header(stripped)
+    if not header:
+        return stripped
+
+    header_lines = header.splitlines(keepends=True)
+    for line in header_lines:
+        if line.startswith("Attribute VB_Base"):
+            return stripped
+
+    # Step 2: no VB_Base in the supplied header.  Find the VB_Name
+    # anchor to insert after.
+    insert_at = -1
+    for i, line in enumerate(header_lines):
+        if line.startswith("Attribute VB_Name"):
+            insert_at = i + 1
+            break
+    if insert_at == -1:
+        return stripped
+
+    anchor = header_lines[insert_at - 1]
+    if anchor.endswith("\r\n"):
+        eol = "\r\n"
+    elif anchor.endswith("\n"):
+        eol = "\n"
+    else:
+        # Header ends without a newline; terminate the anchor so the
+        # inserted line starts on its own line.
+        eol = "\r\n"
+        header_lines[insert_at - 1] = anchor + eol
+
+    vb_base_line = ""
+    if prior_header:
+        for line in prior_header.splitlines():
+            if line.startswith("Attribute VB_Base"):
+                vb_base_line = line.rstrip("\r\n") + eol
+                break
+    if not vb_base_line:
+        vb_base_line = f'Attribute VB_Base = "{CLASS_MODULE_CLSID}"{eol}'
+
+    header_lines.insert(insert_at, vb_base_line)
+    return "".join(header_lines) + body
 
 
 def rebuild_module_stream(module: VBAModule, code_page: int) -> bytes:

--- a/src/pyopenvba/word.py
+++ b/src/pyopenvba/word.py
@@ -30,11 +30,13 @@ from pyopenvba.vba import (
     compress,
     detect_signature,
     invalidate_vba_project_cache,
+    normalize_class_source,
     parse_vba_project,
     rebuild_module_stream,
     serialize_dir_stream,
     serialize_project_stream,
     serialize_projectwm,
+    split_attribute_header,
     write_back_modules,
 )
 
@@ -145,13 +147,26 @@ class WordFile:
         automatically re-prepended so document modules keep their host-binding
         ``Attribute VB_*`` lines.
 
+        When the target is a class-kind module (``VBAModuleKind.other``),
+        a supplied full source is normalized from file-export form to
+        stream form first (``VERSION ... CLASS`` preamble stripped,
+        ``Attribute VB_Base`` preserved or restored), so ``.cls`` files
+        exported from the VBE are accepted as-is.
+
         Changes are not written to disk until :meth:`save` is called.
         """
-        from pyopenvba.vba import split_attribute_header
         project = self.vba_project()
         for m in project.modules:
             if m.name.casefold() == name.casefold():
                 supplied_header, _ = split_attribute_header(source)
+                if supplied_header and m.kind == VBAModuleKind.other:
+                    # Convert file-export form to stream form.  prior_header
+                    # keeps the module's existing VB_Base line (including
+                    # host CLSIDs on document modules, which share the
+                    # 0x0022 module kind with plain classes).
+                    prior = m.attribute_header or split_attribute_header(m.source)[0]
+                    source = normalize_class_source(source, prior_header=prior)
+                    supplied_header, _ = split_attribute_header(source)
                 if supplied_header:
                     m.source = source
                     m.attribute_header = supplied_header
@@ -250,8 +265,18 @@ class WordFile:
                 continue
             raw = child.read_bytes().decode(encoding, errors="replace")
             text = raw.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
+            new_header = ""
+            if module.kind == VBAModuleKind.other and split_attribute_header(text)[0]:
+                # Class-kind files may be VBE exports (file-export form);
+                # convert to stream form, preserving the module's existing
+                # VB_Base line via prior_header.
+                prior = module.attribute_header or split_attribute_header(module.source)[0]
+                text = normalize_class_source(text, prior_header=prior)
+                new_header = split_attribute_header(text)[0]
             if module.source != text:
                 module.source = text
+                if new_header:
+                    module.attribute_header = new_header
                 module.dirty = True
             updated.append(module.name)
         return updated

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -10,6 +10,11 @@ import pytest
 
 from pyopenvba.excel import ExcelFile
 from pyopenvba.exceptions import UnsupportedFormatError, VBAProjectError
+from pyopenvba.vba import (
+    CLASS_MODULE_CLSID,
+    VBAModuleKind,
+    split_attribute_header,
+)
 
 _VBA_ENTRY = "xl/vbaProject.bin"
 
@@ -145,3 +150,108 @@ def test_vba_module_disassemble_returns_empty_when_no_prefix() -> None:
     assert disasm.cafe_offset == -1
     assert disasm.num_lines == 0
     assert disasm.lines == ()
+
+
+# ---------------------------------------------------------------------------
+# Class-source normalization at the facade entry points (GitHub issue #1)
+# ---------------------------------------------------------------------------
+
+_VB_BASE_LINE = f'Attribute VB_Base = "{CLASS_MODULE_CLSID}"'
+
+_EXPORT_FORM_CLS = (
+    "VERSION 1.0 CLASS\r\n"
+    "BEGIN\r\n"
+    "  MultiUse = -1  'True\r\n"
+    "END\r\n"
+    'Attribute VB_Name = "Class1"\r\n'
+    "Attribute VB_GlobalNameSpace = False\r\n"
+    "Attribute VB_Creatable = False\r\n"
+    "Attribute VB_PredeclaredId = False\r\n"
+    "Attribute VB_Exposed = False\r\n"
+    "\r\n"
+    "Private mMessage As String\r\n"
+    "\r\n"
+    "Public Function Greet() As String\r\n"
+    '    Greet = "Class1.Greet: " & mMessage\r\n'
+    "End Function\r\n"
+)
+
+
+def _new_workbook_with_class(path: Path) -> None:
+    """Create an .xlsm containing a correctly-formed Class1 and save it."""
+    with ExcelFile.create_new(path) as wb:
+        project = wb.vba_project()
+        project.add_module(
+            "Class1", "Private mMessage As String\r\n", kind=VBAModuleKind.other
+        )
+        wb.save()
+
+
+class TestClassSourceNormalization:
+    def test_set_module_normalizes_export_form_class(self, tmp_path: Path) -> None:
+        target = tmp_path / "book.xlsm"
+        _new_workbook_with_class(target)
+        with ExcelFile(target) as wb:
+            wb.set_module("Class1", _EXPORT_FORM_CLS)
+            wb.save()
+        with ExcelFile(target) as wb:
+            source = wb.get_module("Class1")
+        assert not source.startswith("VERSION")
+        header, _ = split_attribute_header(source)
+        assert _VB_BASE_LINE in header
+        assert source.endswith("End Function\r\n")
+
+    def test_set_module_preserves_document_module_host_clsid(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "book.xlsm"
+        with ExcelFile.create_new(target) as wb:
+            project = wb.vba_project()
+            prior_header = project.get_module("ThisWorkbook").attribute_header
+            prior_vb_base = next(
+                line
+                for line in prior_header.splitlines()
+                if line.startswith("Attribute VB_Base")
+            )
+            # A document module's host CLSID differs from the universal
+            # class CLSID; the assertion below relies on that.
+            assert CLASS_MODULE_CLSID not in prior_vb_base
+            # Full-source replacement whose header lacks VB_Base entirely.
+            supplied = (
+                'Attribute VB_Name = "ThisWorkbook"\r\n'
+                "\r\n"
+                "Private Sub Workbook_Open()\r\nEnd Sub\r\n"
+            )
+            wb.set_module("ThisWorkbook", supplied)
+            new_header = project.get_module("ThisWorkbook").attribute_header
+        assert prior_vb_base in new_header
+        assert CLASS_MODULE_CLSID not in new_header
+
+    def test_push_modules_normalizes_export_form_cls(self, tmp_path: Path) -> None:
+        target = tmp_path / "book.xlsm"
+        _new_workbook_with_class(target)
+        src_dir = tmp_path / "vba"
+        src_dir.mkdir()
+        (src_dir / "Class1.cls").write_bytes(_EXPORT_FORM_CLS.encode("utf-8"))
+        with ExcelFile(target) as wb:
+            updated = wb.push_modules(src_dir)
+            assert updated == ["Class1"]
+            module = wb.vba_project().get_module("Class1")
+            assert module.dirty
+            assert not module.source.startswith("VERSION")
+            assert _VB_BASE_LINE in module.attribute_header
+            wb.save()
+        # Pushing the same file again normalizes to the identical text and
+        # leaves the module clean.
+        with ExcelFile(target) as wb:
+            wb.push_modules(src_dir)
+            assert not wb.vba_project().get_module("Class1").dirty
+
+    def test_pull_then_push_round_trip_stays_clean(self, tmp_path: Path) -> None:
+        target = tmp_path / "book.xlsm"
+        _new_workbook_with_class(target)
+        pulled = tmp_path / "pulled"
+        with ExcelFile(target) as wb:
+            wb.pull_modules(pulled)
+            wb.push_modules(pulled)
+            assert not any(m.dirty for m in wb.vba_project().modules)

--- a/tests/test_powerpoint.py
+++ b/tests/test_powerpoint.py
@@ -281,3 +281,38 @@ class TestPullPushPptHelpers:
 
         updated = push_ppt(src, out)
         assert isinstance(updated, list)
+
+
+class TestPowerPointClassSourceNormalization:
+    """set_module on a class-kind target normalizes VBE export form
+    (GitHub issue #1); PowerPointFile carries its own copy of set_module."""
+
+    def test_set_module_normalizes_export_form_class(self, tmp_path: Path) -> None:
+        from pyopenvba.vba import (
+            CLASS_MODULE_CLSID,
+            VBAModuleKind,
+            split_attribute_header,
+        )
+
+        export_form = (
+            "VERSION 1.0 CLASS\r\n"
+            "BEGIN\r\n"
+            "  MultiUse = -1  'True\r\n"
+            "END\r\n"
+            'Attribute VB_Name = "Class1"\r\n'
+            "Attribute VB_Exposed = False\r\n"
+            "\r\n"
+            "Private mMessage As String\r\n"
+        )
+        target = tmp_path / "prs.pptm"
+        with PowerPointFile.create_new(target) as prs:
+            prs.vba_project().add_module(
+                "Class1", "Private x As Long\r\n", kind=VBAModuleKind.other
+            )
+            prs.save()
+        with PowerPointFile(target) as prs:
+            prs.set_module("Class1", export_form)
+            source = prs.get_module("Class1")
+        assert not source.startswith("VERSION")
+        header, _ = split_attribute_header(source)
+        assert f'Attribute VB_Base = "{CLASS_MODULE_CLSID}"' in header

--- a/tests/test_vba.py
+++ b/tests/test_vba.py
@@ -8,7 +8,17 @@ from pathlib import Path
 import pytest
 
 from pyopenvba.exceptions import VBAProjectError
-from pyopenvba.vba import compress, copy_token_help, decompress
+from pyopenvba.vba import (
+    CLASS_MODULE_CLSID,
+    VBAModuleKind,
+    VBAProject,
+    compress,
+    copy_token_help,
+    decompress,
+    normalize_class_source,
+    split_attribute_header,
+    synthesize_class_header,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -620,3 +630,169 @@ def test_compress_byte_exact_against_access_sample_040():
             )
             return
     pytest.skip("module M not located in sample 040")
+
+
+# ---------------------------------------------------------------------------
+# Class-source normalization (GitHub issue #1)
+# ---------------------------------------------------------------------------
+#
+# VBE-exported .cls files are in *file-export form*: a leading
+# ``VERSION 1.0 CLASS`` / ``BEGIN`` / ``END`` preamble and NO
+# ``Attribute VB_Base`` line.  Module streams need *stream form*: no
+# VERSION preamble, WITH VB_Base.  Both differences are independently
+# fatal in live Excel (missing VB_Base: "Invalid procedure call or
+# argument" at the first ``New`` site; VERSION preamble in the stream:
+# "Compile error: Expected: end of statement" on line 1 of the class).
+
+_VB_BASE_LINE = f'Attribute VB_Base = "{CLASS_MODULE_CLSID}"'
+
+# The reporter's fixture shape from issue #1: own attribute header,
+# no VB_Base, LF line endings.
+_ISSUE1_HEADERED_CLS_LF = (
+    'Attribute VB_Name = "Class1"\n'
+    "Attribute VB_GlobalNameSpace = False\n"
+    "Attribute VB_Creatable = False\n"
+    "Attribute VB_PredeclaredId = False\n"
+    "Attribute VB_Exposed = False\n"
+    "\n"
+    "Private mMessage As String\n"
+    "\n"
+    "Public Function Greet() As String\n"
+    '    Greet = "Class1.Greet: " & mMessage\n'
+    "End Function\n"
+)
+
+# A genuine VBE export: VERSION preamble + the same header, CRLF.
+_VBE_EXPORT_CLS_CRLF = (
+    "VERSION 1.0 CLASS\r\n"
+    "BEGIN\r\n"
+    "  MultiUse = -1  'True\r\n"
+    "END\r\n"
+    'Attribute VB_Name = "Class1"\r\n'
+    "Attribute VB_GlobalNameSpace = False\r\n"
+    "Attribute VB_Creatable = False\r\n"
+    "Attribute VB_PredeclaredId = False\r\n"
+    "Attribute VB_Exposed = False\r\n"
+    "\r\n"
+    "Private mMessage As String\r\n"
+)
+
+
+class TestNormalizeClassSource:
+    def test_inserts_vb_base_after_vb_name_preserving_lf(self) -> None:
+        out = normalize_class_source(_ISSUE1_HEADERED_CLS_LF)
+        lines = out.split("\n")
+        assert lines[0] == 'Attribute VB_Name = "Class1"'
+        assert lines[1] == _VB_BASE_LINE
+        assert "\r\n" not in out
+        # Body untouched.
+        assert out.endswith("End Function\n")
+
+    def test_strips_version_preamble_and_inserts_vb_base_crlf(self) -> None:
+        out = normalize_class_source(_VBE_EXPORT_CLS_CRLF)
+        assert not out.startswith("VERSION")
+        assert "MultiUse" not in out
+        lines = out.split("\r\n")
+        assert lines[0] == 'Attribute VB_Name = "Class1"'
+        assert lines[1] == _VB_BASE_LINE
+        assert out.endswith("Private mMessage As String\r\n")
+
+    def test_stream_form_input_is_unchanged(self) -> None:
+        stream_form = synthesize_class_header("Class1") + "\r\nPrivate x As Long\r\n"
+        assert normalize_class_source(stream_form) == stream_form
+
+    def test_idempotent(self) -> None:
+        once = normalize_class_source(_VBE_EXPORT_CLS_CRLF)
+        assert normalize_class_source(once) == once
+
+    def test_prior_header_vb_base_wins_over_universal_clsid(self) -> None:
+        host_base = 'Attribute VB_Base = "0{00020819-0000-0000-C000-000000000046}"'
+        prior = (
+            'Attribute VB_Name = "ThisWorkbook"\r\n'
+            f"{host_base}\r\n"
+            "Attribute VB_Exposed = True\r\n"
+        )
+        supplied = (
+            'Attribute VB_Name = "ThisWorkbook"\r\n'
+            "Attribute VB_Exposed = True\r\n"
+            "\r\n"
+            "Private Sub Workbook_Open()\r\nEnd Sub\r\n"
+        )
+        out = normalize_class_source(supplied, prior_header=prior)
+        assert host_base in out
+        assert CLASS_MODULE_CLSID not in out
+
+    def test_supplied_vb_base_is_kept(self) -> None:
+        custom = 'Attribute VB_Base = "0{DEADBEEF-0000-0000-C000-000000000046}"'
+        src = (
+            'Attribute VB_Name = "C"\r\n'
+            f"{custom}\r\n"
+            "\r\n"
+            "Private x As Long\r\n"
+        )
+        assert normalize_class_source(src) == src
+
+    def test_version_preamble_with_bare_body_yields_bare_body(self) -> None:
+        src = (
+            "VERSION 1.0 CLASS\r\n"
+            "BEGIN\r\n"
+            "  MultiUse = -1  'True\r\n"
+            "END\r\n"
+            "Private x As Long\r\n"
+        )
+        assert normalize_class_source(src) == "Private x As Long\r\n"
+
+    def test_header_without_vb_name_anchor_is_left_alone(self) -> None:
+        src = (
+            "Attribute VB_GlobalNameSpace = False\r\n"
+            "\r\n"
+            "Private x As Long\r\n"
+        )
+        assert normalize_class_source(src) == src
+
+    def test_empty_source(self) -> None:
+        assert normalize_class_source("") == ""
+
+
+class TestAddModuleClassNormalization:
+    def test_headered_cls_without_vb_base_is_normalized(self) -> None:
+        project = VBAProject()
+        module = project.add_module(
+            "Class1", _ISSUE1_HEADERED_CLS_LF, kind=VBAModuleKind.other
+        )
+        header, _ = split_attribute_header(module.source)
+        assert _VB_BASE_LINE in header
+        assert module.attribute_header == header
+
+    def test_vbe_export_form_is_normalized(self) -> None:
+        project = VBAProject()
+        module = project.add_module(
+            "Class1", _VBE_EXPORT_CLS_CRLF, kind=VBAModuleKind.other
+        )
+        assert not module.source.startswith("VERSION")
+        header, _ = split_attribute_header(module.source)
+        assert _VB_BASE_LINE in header
+
+    def test_version_preamble_with_bare_body_gets_synthesized_header(self) -> None:
+        src = (
+            "VERSION 1.0 CLASS\r\n"
+            "BEGIN\r\n"
+            "  MultiUse = -1  'True\r\n"
+            "END\r\n"
+            "Private x As Long\r\n"
+        )
+        project = VBAProject()
+        module = project.add_module("Class1", src, kind=VBAModuleKind.other)
+        assert module.attribute_header == synthesize_class_header("Class1")
+        assert module.source.endswith("Private x As Long\r\n")
+
+    def test_standard_module_with_header_is_untouched(self) -> None:
+        src = (
+            'Attribute VB_Name = "Module1"\r\n'
+            "\r\n"
+            "Sub Hello()\r\nEnd Sub\r\n"
+        )
+        project = VBAProject()
+        module = project.add_module("Module1", src, kind=VBAModuleKind.standard)
+        assert module.source == src
+        assert CLASS_MODULE_CLSID not in module.source

--- a/tests/test_word.py
+++ b/tests/test_word.py
@@ -320,3 +320,38 @@ class TestPullPushWordHelpers:
 
         updated = push_word(src, out)
         assert isinstance(updated, list)
+
+
+class TestWordClassSourceNormalization:
+    """set_module on a class-kind target normalizes VBE export form
+    (GitHub issue #1); WordFile carries its own copy of set_module."""
+
+    def test_set_module_normalizes_export_form_class(self, tmp_path: Path) -> None:
+        from pyopenvba.vba import (
+            CLASS_MODULE_CLSID,
+            VBAModuleKind,
+            split_attribute_header,
+        )
+
+        export_form = (
+            "VERSION 1.0 CLASS\r\n"
+            "BEGIN\r\n"
+            "  MultiUse = -1  'True\r\n"
+            "END\r\n"
+            'Attribute VB_Name = "Class1"\r\n'
+            "Attribute VB_Exposed = False\r\n"
+            "\r\n"
+            "Private mMessage As String\r\n"
+        )
+        target = tmp_path / "doc.docm"
+        with WordFile.create_new(target) as doc:
+            doc.vba_project().add_module(
+                "Class1", "Private x As Long\r\n", kind=VBAModuleKind.other
+            )
+            doc.save()
+        with WordFile(target) as doc:
+            doc.set_module("Class1", export_form)
+            source = doc.get_module("Class1")
+        assert not source.startswith("VERSION")
+        header, _ = split_attribute_header(source)
+        assert f'Attribute VB_Base = "{CLASS_MODULE_CLSID}"' in header


### PR DESCRIPTION
VBE-exported .cls files are in file-export form: a leading VERSION 1.0 CLASS / BEGIN / END preamble and no Attribute VB_Base line. Module streams need the opposite: no VERSION preamble, with VB_Base. add_module, set_module, and push_modules wrote supplied headers into the stream verbatim, so class modules built from export-form sources failed to compile in Excel: a missing VB_Base raises "Invalid procedure call or argument" at the first New site, and a VERSION preamble is parsed as class body text and raises "Expected: end of statement". Both failure modes verified against live Excel, as is the fix.

New normalize_class_source() in vba.py strips the preamble and inserts VB_Base after VB_Name when missing. On replacement of an existing module the prior header's VB_Base line is kept, so document-module host CLSIDs are never overwritten (document modules share MODULETYPE 0x0022 with plain classes). Applied in VBAProject.add_module and each host facade's set_module and push_modules. Bare-body and standard-module paths are unchanged.