### PR TITLE
Release 3.3.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 All notable changes to pyOpenVBA are documented here. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.3.0] - 2026-08-01
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyOpenVBA"
-version = "3.2.0"
+version = "3.3.0"
 description = "Read and write VBA macros inside Excel, Word, and PowerPoint files in pure Python, no dependencies."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/pyopenvba/__init__.py
+++ b/src/pyopenvba/__init__.py
@@ -204,4 +204,4 @@ __all__ = [
     "push_word",
 ]
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"


### PR DESCRIPTION
Version bump and changelog for 3.3.0: Excel fixture CI on real Office (#4, @DecimalTurn) and ExcelFile.create_new .xlam support (#9). Full battery green locally (392 tests, pyright strict, ruff).