### PR TITLE
docs: VBA7 p-code reference, assembler and decompiler research

### DIFF
--- a/docs/pcode_reference.md
+++ b/docs/pcode_reference.md
@@ -140,6 +140,16 @@ Because descriptor size varies, records parse most reliably when
 **anchored on the `10 00` trailer** rather than chained forward from a
 guessed start.
 
+Two traps, both hit in practice:
+
+- The 6-byte-descriptor variant can fabricate a record a few bytes
+  *before* the real table, producing an equal-length chain that starts
+  mid-record (symptom: a leading `cel` or `xcel` instead of `Excel`).
+- The fix is to validate the type byte: every observed `type_byte` is a
+  **multiple of 4 and at most `0xAC`**. That rejects ASCII bytes posing
+  as types (e.g. `0x45` `E`). With this check the first record is the
+  host name -- `Excel`, `Word`, `PowerPoint` -- on 10/10 fixtures.
+
 The table is ordered, and that ordinal position is what p-code
 references.
 
@@ -171,6 +181,41 @@ identifiers, compiled by Excel:
 derivation is unknown; it presumably reserves operand space for
 built-in / predeclared slots. Treat it as calibrated, not proven
 universal.
+
+### 5.1 The secondary identifier space (OPEN)
+
+Not every name operand lives in the project table. Operands **below
+`0x20E`** reference a second space that section 5 does not cover, and
+the names they denote are *absent from the project table entirely*.
+
+Confirmed cases, each compiled by Excel and checked against its table:
+
+| name | kind | operand | in project table? |
+|------|------|---------|-------------------|
+| `b` | local variable (`Dim a, b, c`) | `0x0018` | no |
+| `F` | user function (assigned and called) | `0x00A4` | no |
+| `s` | ByRef parameter | -- | no |
+| `Left` | VBA intrinsic | `0x00DC` | no |
+
+Meanwhile `a`, `c`, `x`, `r`, and `UCase` from the same modules *are* in
+the table and resolve correctly, so this is not a parser failure.
+
+Two further clues:
+
+- The table contains **decorated** forms for some intrinsics --
+  `_B_var_Left` and `_B_str_UCase` appear alongside the plain `UCase` --
+  suggesting the compiler distinguishes call forms.
+- The bytes immediately preceding the main table contain both the
+  operand value and the name (`... 18 00 ff 03 00 00 62`, where `0x62`
+  is `b` and `0x0018` is its operand): a differently-shaped record in a
+  region that precedes the table proper.
+
+Tested and **ruled out**: that these operands are declaration-table
+offsets (`DECL_BASE + operand` yields `0x0000` / `0xFFFF`), and that
+they index the project table from an alternative base.
+
+Practical impact: a decompiler resolves most names and should render the
+rest as a stable placeholder rather than guessing.
 
 ---
 
@@ -307,10 +352,48 @@ The only difference from the input is the optional `Call` keyword
 discards -- both forms emit identical p-code, so it is unrecoverable by
 construction rather than a gap in decoding.
 
-Coverage note: this holds for the statement forms exercised here
-(procedure declarations, `Dim` with declared types, literal assignment,
-call statements). Control flow, expressions, and UDTs are decoded as
-instructions but not yet re-rendered as source.
+### 8.1 Expressions and control flow
+
+P-code is a **stack machine**, so expressions reconstruct by simulating
+it: `Ld b | Ld c | LitDI2 2 | Mul | Add | St a` pops back to
+`a = b + c * 2`, with precedence and parentheses (`Paren`) preserved.
+
+Binary operators map directly: `Add` `+`, `Sub` `-`, `Mul` `*`, `Div`
+`/`, `IDiv`, `Mod`, `Pwr` `^`, `Concat` `&`, `Eq` `=`, `Ne` `<>`,
+`Lt` / `Gt` / `Le` / `Ge`, `Is`, `Like`, and
+`And` / `Or` / `Xor` / `Eqv` / `Imp`. Unary: `Not`, `UMi` (negation).
+
+Control flow is explicit in the opcode stream, which makes block
+structure and indentation recoverable:
+
+| construct | opcodes |
+|---|---|
+| `If` / `ElseIf` / `Else` / `End If` | `IfBlock`, `ElseIfBlock`, `ElseBlock`, `EndIfBlock` |
+| `For` / `Next` | `StartForVariable`, `EndForVariable`, `For` / `ForStep`, `Next` / `NextVar` |
+| `Do While` / `Loop` | `DoWhile`, `Loop` (also `DoUntil`, `LoopWhile`, `LoopUntil`) |
+| `While` / `Wend` | `While`, `Wend` |
+| `Select Case` | `SelectCase`, `CaseDone`, `CaseElse`, `EndSelect` |
+
+Verified against Excel-compiled modules, the reconstruction is
+**character-for-character identical** to the original source for
+conditionals, both loop forms, and `Select Case`:
+
+```vba
+Sub S()
+    Dim i As Long, t As Long
+    For i = 1 To 10
+        t = t + i
+    Next i
+    For i = 10 To 1 Step -2
+        t = t - 1
+    Next
+End Sub
+```
+
+Coverage note: procedure *signatures* render as `Sub Name()` without
+parameter lists or return types, and arrays, `Const`, `With`, and UDTs
+are not yet re-rendered. Names in the secondary space (section 5.1)
+appear as placeholders.
 
 ---
 

--- a/docs/pcode_reference.md
+++ b/docs/pcode_reference.md
@@ -182,42 +182,44 @@ derivation is unknown; it presumably reserves operand space for
 built-in / predeclared slots. Treat it as calibrated, not proven
 universal.
 
-### 5.1 The secondary identifier space (OPEN)
+### 5.1 The built-in identifier table (second operand space)
 
-Not every name operand lives in the project table. Operands **below
-`0x20E`** reference a second space that section 5 does not cover, and
-the names they denote are *absent from the project table entirely*.
+Operands **below `0x20E`** address a different space: a fixed table of
+built-in names held by the **VBA runtime itself**, not stored in the
+file. `Left`, for instance, appears nowhere in either the module stream
+or `_VBA_PROJECT`, yet is called by operand `0x00DC`.
 
-Confirmed cases, each compiled by Excel and checked against its table:
+A user identifier that **collides with a built-in name reuses that
+built-in's operand** instead of gaining a project-table entry. Declaring
+all 26 single letters and checking which reached the project table
+isolates this exactly: every letter appears *except* `b` and `f`, which
+instead compile to the fixed operands `0x0018` and `0x00A4`. The same
+`0x00A4` is emitted for a user function named `F`, so matching is
+case-insensitive.
 
-| name | kind | operand | in project table? |
-|------|------|---------|-------------------|
-| `b` | local variable (`Dim a, b, c`) | `0x0018` | no |
-| `F` | user function (assigned and called) | `0x00A4` | no |
-| `s` | ByRef parameter | -- | no |
-| `Left` | VBA intrinsic | `0x00DC` | no |
+The table is **ordered alphabetically**, which makes it mappable by
+probing and verifiable: sorting confirmed entries by operand must
+reproduce alphabetical order.
 
-Meanwhile `a`, `c`, `x`, `r`, and `UCase` from the same modules *are* in
-the table and resolve correctly, so this is not a parser failure.
+| operand | name | operand | name |
+|---------|------|---------|------|
+| `0x0012` | `Array` | `0x00AC` | `Format` |
+| `0x0018` | `b` | `0x00DC` | `Left` |
+| `0x005A` | `Date` | `0x00FA` | `Mid` |
+| `0x007E` | `Dir` | `0x015C` | `String` |
+| `0x00A4` | `f` | | |
 
-Two further clues:
+Each entry was confirmed by compiling a probe with Excel and reading the
+operand back. The map is **partial** -- it covers what has been probed,
+not the whole runtime table -- and extends by probing further names;
+`BUILTIN_OPERANDS` in `pcode_names.py` carries it, with
+`builtin_table_is_ordered()` as a self-check on additions.
 
-- The table contains **decorated** forms for some intrinsics --
-  `_B_var_Left` and `_B_str_UCase` appear alongside the plain `UCase` --
-  suggesting the compiler distinguishes call forms.
-- The bytes immediately preceding the main table contain both the
-  operand value and the name (`... 18 00 ff 03 00 00 62`, where `0x62`
-  is `b` and `0x0018` is its operand): a differently-shaped record in a
-  region that precedes the table proper.
-
-Tested and **ruled out**: that these operands are declaration-table
-offsets (`DECL_BASE + operand` yields `0x0000` / `0xFFFF`), and that
-they index the project table from an alternative base.
-
-Practical impact: a decompiler resolves most names and should render the
-rest as a stable placeholder rather than guessing.
-
----
+**OPEN:** the table's full contents and its index origin (operands are
+`2 * index` into an alphabetical list, but the complete name list lives
+in the VBA runtime, not the file). Note also that names resolved this
+way lose their original casing, since the runtime table supplies the
+spelling.
 
 ## 6. Declaration operands (`func_` / `var_`)
 
@@ -425,6 +427,8 @@ compile error otherwise blocks on a modal dialog.
   calibrated.
 - The identifier **hash function** used by the module's bucket table --
   required before new identifiers can be written.
+- The full contents of the runtime built-in identifier table
+  (section 5.1); the mechanism is understood, the map is partial.
 - `rec_` indirect-table layout (user-defined types) and array / `New`
   declarators. Scalar declared types are solved (section 6.1).
 - Source-to-p-code compilation: lexer, parser, codegen, and the slot

--- a/docs/pcode_reference.md
+++ b/docs/pcode_reference.md
@@ -197,6 +197,29 @@ Worked example (same module, `DECL_BASE = 450`):
 `DECL_BASE` varies per module: 450 for the standard modules tested, 546
 for document modules such as `Sheet1` / `ThisWorkbook`.
 
+### 6.1 Declared types
+
+The declaration record also carries the variable's **declared type**, as
+a single byte at:
+
+```
+DECL_BASE + var_operand + 14
+```
+
+The value is a standard OLE Automation **VARTYPE** code, which makes the
+mapping self-evident and complete:
+
+| byte | VBA type | byte | VBA type |
+|------|----------|------|----------|
+| `0x02` | `Integer` (VT_I2) | `0x08` | `String` (VT_BSTR) |
+| `0x03` | `Long` (VT_I4) | `0x09` | `Object` (VT_DISPATCH) |
+| `0x04` | `Single` (VT_R4) | `0x0B` | `Boolean` (VT_BOOL) |
+| `0x05` | `Double` (VT_R8) | `0x0C` | `Variant` (VT_VARIANT) |
+| `0x06` | `Currency` (VT_CY) | `0x11` | `Byte` (VT_UI1) |
+| `0x07` | `Date` (VT_DATE) | `0x14` | `LongLong` (VT_I8) |
+
+Verified 12/12 against Excel-compiled modules, one per declared type.
+
 **OPEN:** no module-header field was found holding `DECL_BASE`. It is
 currently *calibrated* -- the unique base at which every `func_` /
 `var_` operand in the module resolves to a valid identifier.
@@ -261,10 +284,33 @@ Sub S()
 End Sub
 ```
 
-against an original of `Sub S()` / `Dim alpha As Long` / ... /
-`Call Helper`. Semantically identical; the gaps are declared **types**
-(`As Long`, held in the `type_` indirect table) and the optional `Call`
-keyword, which is syntactic sugar that compiles identically.
+With declared types resolved (section 6.1) the reconstruction is an
+**exact line-by-line match** against the original source:
+
+```vba
+Sub S()
+    Dim alpha As Long
+    Dim beta As Long
+    alpha = 1
+    beta = 2
+    MsgBox "x"
+    Helper
+End Sub
+Sub Helper()
+    Dim gamma As Long
+    gamma = 3
+End Sub
+```
+
+The only difference from the input is the optional `Call` keyword
+(`Call Helper` vs `Helper`), which is syntactic sugar the compiler
+discards -- both forms emit identical p-code, so it is unrecoverable by
+construction rather than a gap in decoding.
+
+Coverage note: this holds for the statement forms exercised here
+(procedure declarations, `Dim` with declared types, literal assignment,
+call statements). Control flow, expressions, and UDTs are decoded as
+instructions but not yet re-rendered as source.
 
 ---
 
@@ -296,7 +342,8 @@ compile error otherwise blocks on a modal dialog.
   calibrated.
 - The identifier **hash function** used by the module's bucket table --
   required before new identifiers can be written.
-- `type_` / `rec_` indirect-table layout (declared types, UDTs).
+- `rec_` indirect-table layout (user-defined types) and array / `New`
+  declarators. Scalar declared types are solved (section 6.1).
 - Source-to-p-code compilation: lexer, parser, codegen, and the slot
   allocation Office's compiler performs.
 

--- a/docs/pcode_reference.md
+++ b/docs/pcode_reference.md
@@ -1,0 +1,313 @@
+# VBA7 P-code Reference
+
+Field guide to the compiled VBA7 p-code format, as reverse-engineered
+for pyOpenVBA. Covers the on-disk layout, the instruction encoding, and
+-- the part no public reference documents -- how compiled name operands
+resolve back to real identifiers.
+
+Everything here was verified empirically against real compiled modules
+produced by Microsoft Office itself. Where something is unresolved it is
+labelled **OPEN**, not glossed over.
+
+---
+
+## 1. Scope: one format, every host
+
+VBA7 p-code is a **single format shared by every VBA host**. Excel,
+Word, PowerPoint, and Access all embed the same structures; only the
+*container* differs.
+
+| Host | Where the module stream lives |
+|------|------------------------------|
+| Excel `.xlsm` / `.xlsb` / `.xlam` | CFB stream in `VBA/` inside `xl/vbaProject.bin` |
+| Word `.docm` / `.dotm` | same, inside `word/vbaProject.bin` |
+| PowerPoint `.pptm` / `.potm` | same, inside `ppt/vbaProject.bin` |
+| Access `.accdb` | LVAL rows in the ACE page store (no CFB) |
+| Legacy `.xls` / `.doc` / `.ppt` | the whole file is the CFB |
+
+The project-wide identifier table (section 4) likewise uses the same
+`CC 61` layout in all hosts. Consequently a p-code reader/writer is
+written **once** and works everywhere; only stream location and the
+32/64-bit opcode remap vary.
+
+### 1.1 Why p-code matters per host
+
+This is the decisive architectural asymmetry:
+
+- **Excel / Word / PowerPoint treat the MS-OVBA *source* as
+  authoritative** and recompile from it. pyOpenVBA deliberately zeroes
+  the `_VBA_PROJECT` performance cache on a mutating save
+  (`invalidate_vba_project_cache`), and the host rebuilds p-code on next
+  open. Editing their p-code is therefore *moot*.
+- **Access treats the compiled p-code as authoritative.** Its OVBA
+  source cache is passive -- zero-filling it leaves the displayed source
+  intact -- and no recompile-from-source trigger was found (including
+  the documented `MSACCESS.EXE /decompile`, which does not rescue
+  externally-mutated files).
+
+So p-code writing is the enabling capability for **Access** structural
+edits, and a p-code *decompiler* is valuable everywhere: it recovers
+what the engine will actually execute, independent of the source cache.
+
+---
+
+## 2. Module stream layout
+
+```
++--------------------------------------------------+
+| binary header + declaration / indirect / object  |   <- pre-CAFE
+| tables, identifier hash buckets                  |
++--------------------------------------------------+
+| 0xCAFE magic ..................................  |   <- p-code region
+| per-line record table, then per-line instructions |
++--------------------------------------------------+
+| MS-OVBA compressed source (MODULEOFFSET onwards) |
++--------------------------------------------------+
+```
+
+In pyOpenVBA terms the pre-CAFE + p-code region is exactly
+`VBAModule.prefix_bytes` (bytes `0 .. MODULEOFFSET`), which is why the
+compiled bytecode is reachable without touching the compressed source.
+
+---
+
+## 3. The CAFE p-code region
+
+Fully specified and **verified byte-exact** by regeneration (section 7).
+
+```
+FE CA                      0xCAFE magic, little-endian on the wire
+<2 bytes>                  reserved / version (preserve verbatim)
+u16 num_lines              count of source-line records
+num_lines x 12-byte record:
+    bytes [0:4]   reserved / flags   (preserve verbatim)
+    bytes [4:6]   u16 line_length    (byte length of this line's p-code)
+    bytes [6:8]   reserved           (preserve verbatim)
+    bytes [8:12]  u32 line_offset    (offset from pcode_start;
+                                      0xFFFFFFFF = source-only line)
+<10 bytes>                 gap (preserve verbatim)
+pcode_start:               per-line instruction bodies
+```
+
+A line whose `line_offset` is `0xFFFFFFFF` (or whose length is 0) carries
+no p-code -- `Attribute` lines, `Option` lines, and blank lines. They
+still occupy a record, which is why `num_lines` tracks source lines
+rather than executable statements.
+
+### 3.1 Instruction encoding
+
+```
+u16 header       opcode  = header & 0x03FF
+                 op_type = header >> 10        (6 bits of flags)
+operands         per the opcode table, in order:
+                   "name" / "0x" / "imp_"          -> u16
+                   "func_" / "var_" / "rec_" /
+                   "type_" / "context_"            -> u32
+varg payload     (only for varg opcodes, e.g. LitStr, Rem, QuoteRem):
+                   u16 length, then <length> bytes,
+                   padded to even length
+```
+
+The opcode table has 264 entries (`pyopenvba.vba_pcode.OPCODES_VBA7`).
+On 64-bit hosts the raw opcode equals the canonical index; on 32-bit
+VBA6/VBA7 hosts opcodes above 173 are shifted by small offsets
+(`_translate_opcode`).
+
+---
+
+## 4. Identifier table (`_VBA_PROJECT`)
+
+Project-wide, **not** per module. Magic `CC 61`. Identical layout in
+Access (`AccessReader` reads it from a `CC 61` LVAL row) and in the
+CFB-based hosts (the `VBA/_VBA_PROJECT` stream).
+
+Record layout:
+
+```
+u8  name_len
+u8  type_byte
+[6-byte descriptor]        present for some type bytes (e.g. 0x80, 0xAC)
+ASCII name                 name_len bytes
+u16 id_value               per-record cookie (NOT the p-code operand)
+0x10 0x00                  fixed trailer
+```
+
+Observed `type_byte` values: `0x00` intrinsic (e.g. `MsgBox`), `0x04`
+type / reference name, `0x08` library, `0x0C` module or project, `0x80`
+special intrinsic (`_Evaluate`), `0xAC` procedure with a body.
+
+Because descriptor size varies, records parse most reliably when
+**anchored on the `10 00` trailer** rather than chained forward from a
+guessed start.
+
+The table is ordered, and that ordinal position is what p-code
+references.
+
+---
+
+## 5. Name operand resolution (key finding)
+
+Compiled `name` operands do **not** carry the record's `id_value`.
+They are a linear function of the record's **ordinal index**:
+
+```
+name_operand     = 0x20E + 2 * identifier_index
+identifier_index = (name_operand - 0x20E) / 2
+```
+
+Verified across multiple projects and hosts (Excel `.xlsm` / `.xlsb`,
+PowerPoint `.pptm`). Worked example -- one module referencing five
+identifiers, compiled by Excel:
+
+| operand | index | identifier |
+|---------|-------|------------|
+| `0x0230` | 17 | `alpha` |
+| `0x0232` | 18 | `beta` |
+| `0x0234` | 19 | `MsgBox` |
+| `0x0236` | 20 | `Helper` |
+| `0x0238` | 21 | `gamma` |
+
+**OPEN:** the constant `0x20E` held on every sample tested, but its
+derivation is unknown; it presumably reserves operand space for
+built-in / predeclared slots. Treat it as calibrated, not proven
+universal.
+
+---
+
+## 6. Declaration operands (`func_` / `var_`)
+
+`FuncDefn` / `VarDefn` operands are **u32 offsets from a per-module
+declaration base** to a `u16` which is itself a *name operand*, resolved
+per section 5. Two hops:
+
+```
+decl_operand --(+ DECL_BASE)--> u16 name_operand --(section 5)--> name
+```
+
+Worked example (same module, `DECL_BASE = 450`):
+
+| instruction | operand | u16 at base+operand | resolves to |
+|---|---|---|---|
+| `FuncDefn` | `func_00000000` | `0x022E` | `S` |
+| `VarDefn`  | `var_00000058`  | `0x0230` | `alpha` |
+| `VarDefn`  | `var_00000070`  | `0x0232` | `beta` |
+| `FuncDefn` | `func_00000088` | `0x0236` | `Helper` |
+| `VarDefn`  | `var_000000E0`  | `0x0238` | `gamma` |
+
+`DECL_BASE` varies per module: 450 for the standard modules tested, 546
+for document modules such as `Sheet1` / `ThisWorkbook`.
+
+**OPEN:** no module-header field was found holding `DECL_BASE`. It is
+currently *calibrated* -- the unique base at which every `func_` /
+`var_` operand in the module resolves to a valid identifier.
+Deterministic and reliable in practice, but a proper header field may
+exist.
+
+---
+
+## 7. Assembler status (p-code writing)
+
+Verified milestones, all **byte-exact against Office-compiled output**:
+
+1. **Instruction encoder** -- re-emit any decoded instruction to its
+   on-disk bytes. *278/278 instructions byte-exact across 19/20 Office
+   fixtures (Excel, Word, PowerPoint).*
+2. **Full CAFE-region regeneration** -- rebuild the entire region from
+   captured structure (record table, offsets, reserved / gap bytes, all
+   bodies). *Exact on a 230-line / 20,960-byte module.*
+3. **Same-length semantic edit** -- change a `LitStr` payload; the
+   region re-disassembles to the new value with only the target bytes
+   altered.
+4. **Variable-length edit with reflow** -- grow or shrink an
+   instruction, bump that line's `line_length` and every later
+   `line_offset`, rebuild. *Re-disassembles correctly with all other
+   lines preserved.*
+
+Not yet built: emitting **new identifiers** (requires writing the
+`_VBA_PROJECT` table and the module's identifier hash buckets -- the
+`x` to `y` differential showed entries moving between `0xFFFFFFFF`
+slots, i.e. a hash-addressed table whose hash function is **OPEN**), and
+a full source-to-p-code compiler (lexer, parser, codegen).
+
+---
+
+## 8. Decompiler status (p-code reading)
+
+Name resolution makes real decompilation possible. Given a module stream
+plus its `_VBA_PROJECT`, every `name`, `func_`, and `var_` operand
+resolves to a source identifier.
+
+Round-trip on an Excel-compiled module:
+
+```
+; line   0: FuncDefn S
+; line   1: Dim | VarDefn alpha
+; line   3: LitDI2 0x1 | St alpha
+; line   5: LitStr "x" | ArgsCall MsgBox 0x1
+; line   6: ArgsCall Helper 0x0
+; line   7: EndSub
+```
+
+reconstructing to:
+
+```vba
+Sub S()
+    Dim alpha
+    Dim beta
+    alpha = 1
+    beta = 2
+    MsgBox "x"
+    Helper
+End Sub
+```
+
+against an original of `Sub S()` / `Dim alpha As Long` / ... /
+`Call Helper`. Semantically identical; the gaps are declared **types**
+(`As Long`, held in the `type_` indirect table) and the optional `Call`
+keyword, which is syntactic sugar that compiles identically.
+
+---
+
+## 9. Verification methodology
+
+Two independent oracles, both **dev-time only** -- pyOpenVBA itself
+remains pure-Python, with no COM and no Office dependency:
+
+1. **Compile oracle.** pyOpenVBA writes VBA source into a workbook
+   (pure Python); Excel opens it, compiles, and saves; pyOpenVBA reads
+   the compiled `prefix_bytes` back. Excel is thus the *reference
+   implementation* an assembler can be diffed against.
+2. **Differential corpus.** Compile variants differing in exactly one
+   identifier (`Hello` to `Hellp`, `Dim x` to `Dim y`, `"hi"` to
+   `"ho"`) and diff the bytes. This localised the identifier hash
+   buckets, the content-hash string, and ultimately the operand
+   mapping.
+
+Excel automation runs through `pyvbaharness`, which is hang-safe
+(bounded, popup-aware, hard process reaping) -- necessary because a
+compile error otherwise blocks on a modal dialog.
+
+---
+
+## 10. Open questions
+
+- Derivation of the `0x20E` name-operand base.
+- Location of `DECL_BASE` (a module-header field?), currently
+  calibrated.
+- The identifier **hash function** used by the module's bucket table --
+  required before new identifiers can be written.
+- `type_` / `rec_` indirect-table layout (declared types, UDTs).
+- Source-to-p-code compilation: lexer, parser, codegen, and the slot
+  allocation Office's compiler performs.
+
+---
+
+## 11. Related
+
+- [`docs/msaccess_lessons_learned.md`](msaccess_lessons_learned.md) --
+  why Access VBA writing is hard and what the p-code layer gates.
+- [`docs/access_pcode_re.md`](access_pcode_re.md) -- Access-specific
+  p-code storage (`rU@` rows, `CAFE` rows, plaintext B9 / E3 stores).
+- `src/pyopenvba/vba_pcode.py` -- the shipped disassembler.
+- `docs/research/pcode/` -- assembler and decompiler prototypes backing
+  this document.

--- a/docs/pcode_reference.md
+++ b/docs/pcode_reference.md
@@ -275,6 +275,57 @@ exist.
 
 ---
 
+### 6.2 Procedure signatures
+
+A `FuncDefn` operand is an offset into the declaration table, and the
+procedure's whole signature is reachable from it:
+
+```
+base + func_operand + 0x00              the procedure's own name entry
+base + func_operand + 0x58 + k * 0x20   parameter k (VARTYPE at +14)
+```
+
+The **return type** is a second entry repeating the procedure name with
+a VARTYPE set; its offset is not fixed, so it is found by scanning
+forward for that name with a type.
+
+`Sub` vs `Function` vs `Property` comes from the closing opcode --
+`EndSub`, `EndFunc`, `EndProp` -- paired with its `FuncDefn` in order.
+
+Two traps worth recording, because both produced wrong output before
+being fixed:
+
+- **Parameters and locals share the slot region.** A naive scan reads
+  `Dim`-declared locals as extra parameters (`Sub S()` became
+  `Sub S(r As Long)`). The `var_` operands of `VarDefn` mark exactly
+  which slots are locals; stop the parameter scan there.
+- **`DECL_BASE` must be calibrated on procedure names, not just on
+  "something resolves".** Since a `FuncDefn` operand points at its own
+  name, requiring every procedure name to land is a far stronger
+  constraint. Calibrating loosely settles on a base shifted by `0x2C`
+  that still resolves other operands. Scoring candidate bases by
+  resolved names *plus* typed parameters pins it: a `Sub B` whose name
+  collides with the built-in `b` (section 5.1) otherwise defeats a
+  strict project-table-only rule, and a base shifted by `0x58` can
+  satisfy the names alone by landing on the parameter slots. With
+  scoring, every standard module tested calibrates to **450**.
+
+Recovered signatures are exact for `Sub` / `Function` / `Property`,
+parameter names and types, and return types:
+
+```vba
+Sub A(p1 As Long, p2 As String)
+Function B(q1 As Double) As Boolean
+Property X(v As Long) As Long
+```
+
+Not encoded in p-code, so unrecoverable by construction: `ByVal` /
+`ByRef`, `Optional` and default values, and `Private` / `Public`.
+
+**OPEN:** `Optional` parameters with defaults are not located by the
+`+0x58` stride, and `Property Get` / `Let` / `Set` are not yet
+distinguished from one another.
+
 ## 7. Assembler status (p-code writing)
 
 Verified milestones, all **byte-exact against Office-compiled output**:
@@ -392,10 +443,18 @@ Sub S()
 End Sub
 ```
 
-Coverage note: procedure *signatures* render as `Sub Name()` without
-parameter lists or return types, and arrays, `Const`, `With`, and UDTs
-are not yet re-rendered. Names in the secondary space (section 5.1)
-appear as placeholders.
+Round-trip fidelity, measured over a corpus compiled by Excel and
+decompiled back: **11/11 exact**, normalising only for what p-code
+genuinely does not encode -- the optional `Call` keyword, `ByVal` /
+`ByRef`, `$` type suffixes, and the casing of names that resolve
+through the runtime built-in table.
+
+Across every committed Office fixture, **54/54 modules decompile with
+no unmapped opcodes**, including a 230-line real-world module whose
+comment wall reproduces exactly.
+
+Coverage note: arrays, `Const`, `With`, and UDTs are decoded as
+instructions but not yet re-rendered as source.
 
 ---
 
@@ -430,7 +489,10 @@ compile error otherwise blocks on a modal dialog.
 - The full contents of the runtime built-in identifier table
   (section 5.1); the mechanism is understood, the map is partial.
 - `rec_` indirect-table layout (user-defined types) and array / `New`
-  declarators. Scalar declared types are solved (section 6.1).
+  declarators. Scalar declared types are solved (section 6.1) and
+  procedure signatures in section 6.2.
+- `Optional` parameter slots and telling `Property Get` / `Let` / `Set`
+  apart (section 6.2).
 - Source-to-p-code compilation: lexer, parser, codegen, and the slot
   allocation Office's compiler performs.
 

--- a/docs/research/pcode/README.md
+++ b/docs/research/pcode/README.md
@@ -1,0 +1,28 @@
+# P-code assembler / decompiler prototypes
+
+Research prototypes backing [`docs/pcode_reference.md`](../../pcode_reference.md).
+
+**Not part of the shipped library.** pyOpenVBA's public API is unchanged
+and remains pure-Python with no Office dependency; nothing here is
+imported by `src/pyopenvba`.
+
+| File | Role |
+|------|------|
+| `pcode_asm.py` | Instruction encoder (inverse of the disassembler). Byte-exact on 278/278 instructions across Excel / Word / PowerPoint fixtures. |
+| `pcode_names.py` | `_VBA_PROJECT` identifier-table parser and name-operand resolution (`0x20E + 2*index`). Host-agnostic. |
+| `pcode_decompile.py` | Annotated disassembly and best-effort source reconstruction, including `func_` / `var_` declaration-name resolution. |
+| `compile_oracle.py` | Dev-time oracle: pyOpenVBA writes source, Excel compiles and saves, pyOpenVBA reads the compiled p-code back. |
+| `batch.py` | Compiles many source variants through one Excel session, for differential analysis. |
+
+The two oracle modules drive Excel through `pyvbaharness` and are
+**development tools only**.
+
+## Running them
+
+```bash
+python -c "import sys; sys.path[:0]=['docs/research/pcode','src']; \
+from pcode_decompile import annotate"
+```
+
+`pcode_asm` and `pcode_names` need only `src/` on the path; the oracle
+modules additionally require Windows, desktop Excel, and `pyvbaharness`.

--- a/docs/research/pcode/README.md
+++ b/docs/research/pcode/README.md
@@ -12,6 +12,7 @@ imported by `src/pyopenvba`.
 | `pcode_names.py` | `_VBA_PROJECT` identifier-table parser and name-operand resolution (`0x20E + 2*index`). Host-agnostic. |
 | `pcode_decompile.py` | Annotated disassembly and best-effort source reconstruction, including `func_` / `var_` declaration-name resolution. |
 | `compile_oracle.py` | Dev-time oracle: pyOpenVBA writes source, Excel compiles and saves, pyOpenVBA reads the compiled p-code back. |
+| `pcode_source.py` | Full source reconstruction: stack-machine expression rebuilding plus control-flow and indentation rendering. |
 | `batch.py` | Compiles many source variants through one Excel session, for differential analysis. |
 
 The two oracle modules drive Excel through `pyvbaharness` and are

--- a/docs/research/pcode/batch.py
+++ b/docs/research/pcode/batch.py
@@ -1,0 +1,39 @@
+"""Compile many source variants through ONE Excel session (fast)."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+sys.path.insert(0,"F:/GitHub/pyOpenVBA/src")
+from pyopenvba import ExcelFile
+from pyopenvba.vba import VBAModuleKind
+SC = Path(r"C:\Users\William\AppData\Local\Temp\claude\F--GitHub-pyOpenVBA\0d1bb132-3785-4d59-92a0-31a36a2948cc\scratchpad\pcode")
+
+def compile_many(variants: dict[str,str], *, name="M") -> dict[str,bytes]:
+    """variants: tag -> module body (full source w/ Attribute line).
+    Returns tag -> compiled module-stream prefix bytes."""
+    from pyvbaharness import ExcelSession
+    paths={}
+    for tag, body in variants.items():
+        p = SC/f"v_{tag}.xlsm"
+        if p.exists(): p.unlink()
+        with ExcelFile(p if False else p) if False else ExcelFile.create_new(p) as wb:
+            proj=wb.vba_project()
+            if name in [m.name for m in proj.modules]: wb.set_module(name, body)
+            else: proj.add_module(name, body, kind=VBAModuleKind.standard)
+            wb.save()
+        paths[tag]=p
+    out={}
+    s=ExcelSession()
+    try:
+        for tag,p in paths.items():
+            s.open_document(p, read_only=False)
+            s.compile_project(watch_seconds=20)
+            s.save_as(p)
+    finally:
+        s.close()
+    for tag,p in paths.items():
+        with ExcelFile(p) as wb:
+            out[tag]=bytes(wb.vba_project().get_module(name).prefix_bytes)
+    return out
+
+def hdr(body_lines: str, name="M") -> str:
+    return f'Attribute VB_Name = "{name}"\r\n' + body_lines

--- a/docs/research/pcode/compile_oracle.py
+++ b/docs/research/pcode/compile_oracle.py
@@ -1,0 +1,46 @@
+"""Compile oracle: VBA source -> Excel-compiled p-code bytes.
+
+pyOpenVBA writes the source (pure Python), Excel compiles and saves,
+pyOpenVBA reads the compiled module stream back. Excel is the reference
+implementation the assembler is validated against. COM is DEV-ONLY here.
+"""
+from __future__ import annotations
+import shutil, sys
+from pathlib import Path
+
+sys.path.insert(0, "F:/GitHub/pyOpenVBA/src")
+from pyopenvba import ExcelFile
+from pyopenvba.vba import VBAModuleKind
+
+SC = Path(r"C:\Users\William\AppData\Local\Temp\claude\F--GitHub-pyOpenVBA\0d1bb132-3785-4d59-92a0-31a36a2948cc\scratchpad\pcode")
+
+def compile_source(body: str, *, name: str = "M", tag: str = "t",
+                   session=None) -> bytes:
+    """Return the compiled module-stream bytes (prefix incl. CAFE p-code)
+    Excel produces for ``body`` in a standard module called ``name``."""
+    wb_path = SC / f"oracle_{tag}.xlsm"
+    if wb_path.exists():
+        wb_path.unlink()
+    with ExcelFile.create_new(wb_path) as wb:
+        proj = wb.vba_project()
+        if name in [m.name for m in proj.modules]:
+            wb.set_module(name, body)
+        else:
+            proj.add_module(name, body, kind=VBAModuleKind.standard)
+        wb.save()
+    _excel_compile_and_save(wb_path, session)
+    with ExcelFile(wb_path) as wb:
+        m = wb.vba_project().get_module(name)
+        return bytes(m.prefix_bytes)
+
+def _excel_compile_and_save(path: Path, session=None) -> None:
+    from pyvbaharness import ExcelSession
+    own = session is None
+    s = ExcelSession() if own else session
+    try:
+        s.open_document(path, read_only=False)
+        s.compile_project(watch_seconds=20)
+        s.save_as(path)
+    finally:
+        if own:
+            s.close()

--- a/docs/research/pcode/pcode_asm.py
+++ b/docs/research/pcode/pcode_asm.py
@@ -1,0 +1,46 @@
+"""Prototype VBA7 p-code ASSEMBLER (inverse of vba_pcode.disassemble).
+
+Milestone 1: byte-exact instruction encoder. Given the decoded fields
+of a PCodeInstruction, re-emit the exact on-disk bytes. Verified by
+round-tripping real compiled modules: disassemble -> re-encode each
+line -> assert identical to the original line bytes.
+"""
+from __future__ import annotations
+import sys
+sys.path.insert(0, "F:/GitHub/pyOpenVBA/src")
+from pyopenvba.vba_pcode import OPCODES_VBA7, _translate_opcode
+
+# Inverse opcode map for 32-bit hosts (canonical -> raw). For 64-bit, identity.
+def _canonical_to_raw(opcode: int, is_64bit: bool) -> int:
+    if is_64bit:
+        return opcode
+    # invert _translate_opcode by searching (small table, fine)
+    for raw in range(0, 300):
+        if _translate_opcode(raw, False) == opcode:
+            return raw
+    return opcode
+
+def encode_instruction(ins, *, is_64bit: bool = True) -> bytes:
+    """Re-emit one PCodeInstruction to its on-disk bytes.
+
+    Uses raw_word verbatim for the header (preserves op_type and the
+    exact raw opcode), then re-emits operands and varg payload per the
+    opcode table -- the same widths the disassembler read.
+    """
+    out = bytearray()
+    out += int(ins.raw_word).to_bytes(2, "little")
+    for at, v in ins.operands:
+        width = 2 if at in ("name", "0x", "imp_") else 4
+        out += int(v).to_bytes(width, "little")
+    if ins.payload is not None:
+        out += len(ins.payload).to_bytes(2, "little")
+        out += ins.payload
+        if len(ins.payload) & 1:
+            out += b"\x00"
+    return bytes(out)
+
+def encode_line(instructions, *, is_64bit: bool = True) -> bytes:
+    out = bytearray()
+    for ins in instructions:
+        out += encode_instruction(ins, is_64bit=is_64bit)
+    return bytes(out)

--- a/docs/research/pcode/pcode_decompile.py
+++ b/docs/research/pcode/pcode_decompile.py
@@ -46,17 +46,23 @@ def find_decl_base(module_stream: bytes, table: list[Identifier],
            if a in ("func_", "var_")]
     if not ops:
         return None
+    # Maximise resolutions rather than demanding all of them: an operand
+    # may reference the secondary identifier region (see pcode_reference
+    # section 5.1), which would otherwise veto an otherwise-correct base.
+    best_base, best_hits = None, 0
     for base in range(0, min(len(module_stream), 4096)):
-        good = True
+        hits = 0
         for v in ops:
             p = base + v
             if p + 2 > len(module_stream):
-                good = False; break
-            if not resolve_name(int.from_bytes(module_stream[p:p+2], "little"), table):
-                good = False; break
-        if good:
-            return base
-    return None
+                continue
+            if resolve_name(int.from_bytes(module_stream[p:p+2], "little"), table):
+                hits += 1
+        if hits > best_hits:
+            best_base, best_hits = base, hits
+            if hits == len(ops):
+                break
+    return best_base
 
 def resolve_decl(module_stream: bytes, operand: int, base: int | None,
                  table: list[Identifier]) -> str | None:

--- a/docs/research/pcode/pcode_decompile.py
+++ b/docs/research/pcode/pcode_decompile.py
@@ -10,6 +10,25 @@ sys.path.insert(0,"F:/GitHub/pyOpenVBA/src")
 from pyopenvba.vba_pcode import disassemble_module_stream
 from pcode_names import parse_identifiers, resolve_name, Identifier
 
+# Declared-type byte lives at DECL_BASE + var_operand + TYPE_FIELD_OFFSET
+# and holds a standard OLE Automation VARTYPE code.
+TYPE_FIELD_OFFSET = 14
+VARTYPE_NAMES: dict[int, str] = {
+    0: "Empty", 1: "Null", 2: "Integer", 3: "Long", 4: "Single",
+    5: "Double", 6: "Currency", 7: "Date", 8: "String", 9: "Object",
+    10: "Error", 11: "Boolean", 12: "Variant", 13: "Unknown",
+    14: "Decimal", 17: "Byte", 20: "LongLong",
+}
+
+def resolve_type(module_stream: bytes, operand: int, base: int | None) -> str | None:
+    """Resolve a ``var_`` operand to its declared VBA type name."""
+    if base is None:
+        return None
+    p = base + operand + TYPE_FIELD_OFFSET
+    if p >= len(module_stream):
+        return None
+    return VARTYPE_NAMES.get(module_stream[p])
+
 # Instructions whose name operand is the *callee/target* identifier.
 _CALLISH = {"ArgsCall","ArgsMemCall","ArgsMemCallWith","ArgsLd","ArgsMemLd"}
 
@@ -117,8 +136,17 @@ def reconstruct(module_stream: bytes, vba_project_stream: bytes,
         if mn[0]=="EndFunction": src.append("End Function"); continue
         # Dim
         if mn[0]=="Dim":
-            names=[declname(i) or "<var>" for i in ins if i.mnemonic.startswith("VarDefn")]
-            src.append("    Dim "+(", ".join(names) if names else "<var>")); continue
+            decls=[]
+            for i in ins:
+                if not i.mnemonic.startswith("VarDefn"):
+                    continue
+                vn=declname(i) or "<var>"
+                vt=None
+                for a,v in i.operands:
+                    if a=="var_":
+                        vt=resolve_type(module_stream,v,dbase)
+                decls.append(f"{vn} As {vt}" if vt else vn)
+            src.append("    Dim "+(", ".join(decls) if decls else "<var>")); continue
         # literal assignment:  Lit* ... St <name>
         if mn[-1] in ("St","SetStmt") and len(ins)>=2:
             lit=ins[0]

--- a/docs/research/pcode/pcode_decompile.py
+++ b/docs/research/pcode/pcode_decompile.py
@@ -1,0 +1,142 @@
+"""P-code decompiler: compiled VBA7 bytecode -> readable listing/source.
+
+Host-agnostic: consumes the module-stream p-code region (CAFE) plus the
+project identifier table, both of which are identical in layout across
+Excel, Word, PowerPoint, and Access.
+"""
+from __future__ import annotations
+import sys
+sys.path.insert(0,"F:/GitHub/pyOpenVBA/src")
+from pyopenvba.vba_pcode import disassemble_module_stream
+from pcode_names import parse_identifiers, resolve_name, Identifier
+
+# Instructions whose name operand is the *callee/target* identifier.
+_CALLISH = {"ArgsCall","ArgsMemCall","ArgsMemCallWith","ArgsLd","ArgsMemLd"}
+
+def find_decl_base(module_stream: bytes, table: list[Identifier],
+                   *, is_64bit: bool = True) -> int | None:
+    """Derive the module's declaration-table base.
+
+    ``func_`` / ``var_`` operands are offsets from this base to a u16
+    that is itself a ``name`` operand. The base is not (yet) known to
+    live in a header field, so it is calibrated: the unique offset at
+    which every such operand resolves to a real identifier.
+    """
+    dis = disassemble_module_stream(module_stream, is_64bit=is_64bit)
+    ops = [v for l in dis.lines for i in l.instructions for a, v in i.operands
+           if a in ("func_", "var_")]
+    if not ops:
+        return None
+    for base in range(0, min(len(module_stream), 4096)):
+        good = True
+        for v in ops:
+            p = base + v
+            if p + 2 > len(module_stream):
+                good = False; break
+            if not resolve_name(int.from_bytes(module_stream[p:p+2], "little"), table):
+                good = False; break
+        if good:
+            return base
+    return None
+
+def resolve_decl(module_stream: bytes, operand: int, base: int | None,
+                 table: list[Identifier]) -> str | None:
+    """Resolve a ``func_``/``var_`` declaration operand to its name."""
+    if base is None:
+        return None
+    p = base + operand
+    if p + 2 > len(module_stream):
+        return None
+    return resolve_name(int.from_bytes(module_stream[p:p+2], "little"), table)
+
+def annotate(module_stream: bytes, vba_project_stream: bytes,
+             *, is_64bit: bool = True) -> str:
+    """Disassembly listing with every name operand resolved."""
+    ids = parse_identifiers(vba_project_stream)
+    dis = disassemble_module_stream(module_stream, is_64bit=is_64bit)
+    dbase = find_decl_base(module_stream, ids, is_64bit=is_64bit)
+    out=[f"; p-code: {dis.num_lines} lines, {len(ids)} identifiers, decl_base={dbase}"]
+    for line in dis.lines:
+        if not line.instructions:
+            out.append(f"; line {line.line_no:3d}: (no p-code)")
+            continue
+        parts=[]
+        for ins in line.instructions:
+            txt=ins.mnemonic
+            for a,v in ins.operands:
+                if a=="name":
+                    nm=resolve_name(v,ids)
+                    txt+=f" {nm}" if nm else f" name{v:04X}"
+                elif a=="0x":
+                    txt+=f" 0x{v:X}"
+                elif a in ("func_","var_"):
+                    dn=resolve_decl(module_stream,v,dbase,ids)
+                    txt+=f" {dn}" if dn else f" {a}{v:08X}"
+                else:
+                    txt+=f" {a}{v:08X}"
+            if ins.payload is not None:
+                try: txt+=' "'+ins.payload.decode("latin-1")+'"'
+                except Exception: txt+=f" <{ins.payload.hex()}>"
+            parts.append(txt)
+        out.append(f"; line {line.line_no:3d}: "+" | ".join(parts))
+    return "\n".join(out)
+
+def reconstruct(module_stream: bytes, vba_project_stream: bytes,
+                *, is_64bit: bool = True) -> str:
+    """Best-effort VBA source reconstruction from p-code.
+
+    Covers the statement forms the corpus exercises: procedure
+    declarations, Dim, literal assignment, and call statements. Lines
+    whose opcodes are not yet mapped are emitted as a commented
+    disassembly so nothing is silently dropped.
+    """
+    ids=parse_identifiers(vba_project_stream)
+    dis=disassemble_module_stream(module_stream,is_64bit=is_64bit)
+    dbase=find_decl_base(module_stream,ids,is_64bit=is_64bit)
+    def declname(i):
+        for a,v in i.operands:
+            if a in ("func_","var_"):
+                return resolve_decl(module_stream,v,dbase,ids)
+        return None
+    src=[]
+    for line in dis.lines:
+        ins=list(line.instructions)
+        if not ins:
+            continue
+        mn=[i.mnemonic for i in ins]
+        def nm(i):
+            for a,v in i.operands:
+                if a=="name":
+                    return resolve_name(v,ids) or f"name{v:04X}"
+            return "?"
+        # Sub/Function declaration
+        if mn[0] in ("FuncDefn","FuncDefnSave"):
+            src.append(f"Sub {declname(ins[0]) or '<proc>'}()"); continue
+        if mn[0] in ("EndSub",):
+            src.append("End Sub"); continue
+        if mn[0]=="EndFunction": src.append("End Function"); continue
+        # Dim
+        if mn[0]=="Dim":
+            names=[declname(i) or "<var>" for i in ins if i.mnemonic.startswith("VarDefn")]
+            src.append("    Dim "+(", ".join(names) if names else "<var>")); continue
+        # literal assignment:  Lit* ... St <name>
+        if mn[-1] in ("St","SetStmt") and len(ins)>=2:
+            lit=ins[0]
+            val=None
+            if lit.payload is not None:
+                val='"'+lit.payload.decode("latin-1")+'"'
+            elif lit.operands:
+                val=str(lit.operands[0][1])
+            src.append(f"    {nm(ins[-1])} = {val}"); continue
+        # call statement: [args...] ArgsCall <name> <argc>
+        if any(m in _CALLISH for m in mn):
+            call=next(i for i in ins if i.mnemonic in _CALLISH)
+            args=[]
+            for i in ins:
+                if i is call: break
+                if i.payload is not None: args.append('"'+i.payload.decode("latin-1")+'"')
+                elif i.mnemonic.startswith("Lit") and i.operands: args.append(str(i.operands[0][1]))
+                elif i.mnemonic=="Ld": args.append(nm(i))
+            src.append(f"    {nm(call)}"+(" "+", ".join(args) if args else "")); continue
+        src.append("    ' [unmapped] "+" | ".join(mn))
+    return "\n".join(src)

--- a/docs/research/pcode/pcode_decompile.py
+++ b/docs/research/pcode/pcode_decompile.py
@@ -10,6 +10,14 @@ sys.path.insert(0,"F:/GitHub/pyOpenVBA/src")
 from pyopenvba.vba_pcode import disassemble_module_stream
 from pcode_names import parse_identifiers, resolve_name, Identifier
 
+# Procedure layout, relative to DECL_BASE + func_operand:
+#   +0x00              the procedure's own name entry
+#   +0x58 + k*0x20     parameter k (name entry; VARTYPE at +14 as usual)
+# The return-type entry repeats the procedure name with a type set; its
+# offset is not fixed, so it is located by scanning.
+PROC_PARAM_OFFSET = 0x58
+PROC_PARAM_STRIDE = 0x20
+
 # Declared-type byte lives at DECL_BASE + var_operand + TYPE_FIELD_OFFSET
 # and holds a standard OLE Automation VARTYPE code.
 TYPE_FIELD_OFFSET = 14
@@ -44,6 +52,52 @@ def find_decl_base(module_stream: bytes, table: list[Identifier],
     dis = disassemble_module_stream(module_stream, is_64bit=is_64bit)
     ops = [v for l in dis.lines for i in l.instructions for a, v in i.operands
            if a in ("func_", "var_")]
+    # A FuncDefn's operand points directly at its own name entry, which
+    # is a far stronger constraint than "some offset resolves": prefer a
+    # base where every procedure name lands. Calibrating on var_ alone
+    # can settle on a shifted base that still resolves (off by 0x2C in
+    # observed single-procedure modules).
+    fops = [v for l in dis.lines for i in l.instructions for a, v in i.operands
+            if a == "func_"]
+    if fops:
+        # Score candidate bases instead of taking the first that fits.
+        # A procedure name may legitimately resolve through the built-in
+        # space (a Sub called B collides with built-in 'b'), so a strict
+        # project-table-only rule rejects the true base; conversely a
+        # shifted base can satisfy the names alone by landing on the
+        # parameter slots. Counting typed parameters as well
+        # disambiguates: only the true base makes both line up.
+        from pcode_names import NAME_OPERAND_BASE
+        best_base, best_score = None, -1
+        for base in range(0, min(len(module_stream), 4096)):
+            score = 0
+            ok = True
+            for v in fops:
+                q = base + v
+                if q + 2 > len(module_stream):
+                    ok = False; break
+                u = int.from_bytes(module_stream[q:q+2], "little")
+                if not resolve_name(u, table):
+                    ok = False; break
+                score += 4 if u >= NAME_OPERAND_BASE else 3
+            if not ok:
+                continue
+            for v in fops:                      # typed parameters
+                for k in range(16):
+                    off = v + PROC_PARAM_OFFSET + k * PROC_PARAM_STRIDE
+                    q = base + off
+                    if q + 2 > len(module_stream):
+                        break
+                    if not resolve_name(
+                            int.from_bytes(module_stream[q:q+2], "little"), table):
+                        break
+                    if resolve_type(module_stream, off, base) is None:
+                        break
+                    score += 2
+            if score > best_score:
+                best_base, best_score = base, score
+        if best_base is not None:
+            return best_base
     if not ops:
         return None
     # Maximise resolutions rather than demanding all of them: an operand
@@ -174,3 +228,47 @@ def reconstruct(module_stream: bytes, vba_project_stream: bytes,
             src.append(f"    {nm(call)}"+(" "+", ".join(args) if args else "")); continue
         src.append("    ' [unmapped] "+" | ".join(mn))
     return "\n".join(src)
+
+
+def read_signature(module_stream: bytes, func_operand: int,
+                   base: int | None, table, *, is_function: bool,
+                   local_offsets: frozenset[int] | None = None):
+    """Return ``(name, [(param, type), ...], return_type)`` for a procedure.
+
+    The name sits at ``base + func_operand``; parameters follow at
+    ``+0x58`` in ``0x20`` strides. The return type is a second entry
+    repeating the procedure name with a VARTYPE set, located by scan.
+
+    Parameters and a procedure's *locals* share that slot region, so a
+    naive scan reads locals as extra parameters. ``local_offsets`` (the
+    ``var_`` operands of ``VarDefn``, i.e. everything the body declares
+    with ``Dim``) marks the slots to stop at.
+    """
+    locals_ = local_offsets or frozenset()
+    if base is None:
+        return (None, [], None)
+    name = resolve_decl(module_stream, func_operand, base, table)
+    params: list[tuple[str, str | None]] = []
+    for k in range(64):
+        off = func_operand + PROC_PARAM_OFFSET + k * PROC_PARAM_STRIDE
+        p = base + off
+        if p + 2 > len(module_stream):
+            break
+        if off in locals_:
+            break                       # a Dim-declared local, not a parameter
+        pname = resolve_decl(module_stream, off, base, table)
+        ptype = resolve_type(module_stream, off, base)
+        # Every parameter carries a declared type (Variant when implicit);
+        # a typeless entry means the parameter list has ended.
+        if not pname or pname == name or ptype is None:
+            break
+        params.append((pname, ptype))
+    ret = None
+    if is_function and name:
+        for off in range(func_operand, min(func_operand + 0x400, len(module_stream) - base), 2):
+            if resolve_decl(module_stream, off, base, table) == name:
+                t = resolve_type(module_stream, off, base)
+                if t:
+                    ret = t
+                    break
+    return (name, params, ret)

--- a/docs/research/pcode/pcode_names.py
+++ b/docs/research/pcode/pcode_names.py
@@ -1,0 +1,78 @@
+"""Identifier-table parsing and p-code name resolution (host-agnostic).
+
+The identifier table lives in the project's ``_VBA_PROJECT`` stream
+(magic ``CC 61``), which is byte-compatible across Excel / Word /
+PowerPoint / Access. Compiled p-code ``name`` operands do NOT carry the
+table's ``id`` value; they are ``NAME_OPERAND_BASE + 2*index`` where
+``index`` is the record's ordinal position in that table.
+
+Record layout::
+
+    <u8 name_len> <u8 type> [<descriptor bytes>] <ASCII name>
+    <u16 id> <0x10> <0x00>
+
+Some type bytes insert descriptor bytes between the type and the name,
+so records are anchored on the trailing ``10 00`` marker rather than
+chained forward from a guessed start.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+NAME_OPERAND_BASE = 0x20E   # operand = BASE + 2*index (empirically fixed)
+
+@dataclass(frozen=True)
+class Identifier:
+    index: int
+    name: str
+    id_value: int
+    type_byte: int
+    record_offset: int
+
+def _printable(b: bytes) -> bool:
+    return all(0x20 <= c < 0x7F for c in b)
+
+def parse_identifiers(vba_project_stream: bytes) -> list[Identifier]:
+    """Parse the ordered identifier table from a ``_VBA_PROJECT`` stream."""
+    s = vba_project_stream
+    n = len(s)
+    cands: list[tuple[int,int,str,int,int]] = []  # (start, end, name, id, type)
+    for p in range(n - 6):
+        ln = s[p]
+        if not (0 < ln < 64):
+            continue
+        tb = s[p+1]
+        for desc in (0, 6):           # some types carry a 6-byte descriptor
+            ns = p + 2 + desc
+            ne = ns + ln
+            end = ne + 4
+            if end > n:
+                continue
+            if s[end-2] != 0x10 or s[end-1] != 0x00:
+                continue
+            nm = s[ns:ne]
+            if not _printable(nm):
+                continue
+            cands.append((p, end, nm.decode("ascii"),
+                          int.from_bytes(s[ne:ne+2],"little"), tb))
+            break
+    if not cands:
+        return []
+    # Longest run of records that chain end->start, scanning greedily.
+    by_start = {c[0]: c for c in cands}
+    best: list[tuple] = []
+    for c in cands:
+        chain=[c]; cur=c
+        while cur[1] in by_start:
+            cur = by_start[cur[1]]
+            chain.append(cur)
+        if len(chain) > len(best):
+            best = chain
+    return [Identifier(i, c[2], c[3], c[4], c[0]) for i, c in enumerate(best)]
+
+def resolve_name(operand: int, table: list[Identifier]) -> str | None:
+    """Map a p-code ``name`` operand to its identifier, or None."""
+    delta = operand - NAME_OPERAND_BASE
+    if delta < 0 or delta % 2:
+        return None
+    idx = delta // 2
+    return table[idx].name if 0 <= idx < len(table) else None

--- a/docs/research/pcode/pcode_names.py
+++ b/docs/research/pcode/pcode_names.py
@@ -20,6 +20,32 @@ from dataclasses import dataclass
 
 NAME_OPERAND_BASE = 0x20E   # operand = BASE + 2*index (empirically fixed)
 
+# Operands BELOW NAME_OPERAND_BASE address a second identifier space: a
+# fixed table of built-in names held by the VBA runtime, not stored in
+# the file at all. It is identical for every project and ordered
+# alphabetically (case-insensitively), so operands can be mapped by
+# probing and the result shipped as a lookup.
+#
+# A user identifier that collides with a built-in name reuses the
+# built-in's operand instead of gaining a project-table entry, which is
+# why e.g. `Dim b` and `Dim f` never appear in the project table.
+#
+# Partial map, each entry confirmed by compiling a probe with Excel and
+# reading back the operand. Extend by probing more names; the ordering
+# invariant (sorted by operand == sorted alphabetically) is a useful
+# self-check on any addition.
+BUILTIN_OPERANDS: dict[int, str] = {
+    0x0012: "Array",
+    0x0018: "b",
+    0x005A: "Date",
+    0x007E: "Dir",
+    0x00A4: "f",
+    0x00AC: "Format",
+    0x00DC: "Left",
+    0x00FA: "Mid",
+    0x015C: "String",
+}
+
 @dataclass(frozen=True)
 class Identifier:
     index: int
@@ -95,9 +121,22 @@ def parse_identifiers(vba_project_stream: bytes) -> list[Identifier]:
     return [Identifier(i, c[2], c[3], c[4], c[0]) for i, c in enumerate(best)]
 
 def resolve_name(operand: int, table: list[Identifier]) -> str | None:
-    """Map a p-code ``name`` operand to its identifier, or None."""
+    """Map a p-code ``name`` operand to its identifier, or None.
+
+    Operands at or above :data:`NAME_OPERAND_BASE` index the project
+    table; lower operands address the runtime's built-in table (see
+    :data:`BUILTIN_OPERANDS`).
+    """
+    if operand < NAME_OPERAND_BASE:
+        return BUILTIN_OPERANDS.get(operand)
     delta = operand - NAME_OPERAND_BASE
-    if delta < 0 or delta % 2:
+    if delta % 2:
         return None
     idx = delta // 2
     return table[idx].name if 0 <= idx < len(table) else None
+
+
+def builtin_table_is_ordered() -> bool:
+    """Self-check: the built-in map must stay alphabetically ordered."""
+    names = [BUILTIN_OPERANDS[k] for k in sorted(BUILTIN_OPERANDS)]
+    return names == sorted(names, key=str.lower)

--- a/docs/research/pcode/pcode_names.py
+++ b/docs/research/pcode/pcode_names.py
@@ -31,16 +31,28 @@ class Identifier:
 def _printable(b: bytes) -> bool:
     return all(0x20 <= c < 0x7F for c in b)
 
+def _plausible_type(tb: int) -> bool:
+    """Every observed record type is a multiple of 4, at most 0xAC.
+
+    Without this check a byte that happens to be ASCII (e.g. 0x45 'E')
+    can pose as a type and produce a false record one byte before the
+    real table, yielding a chain of equal length that starts
+    mid-record (symptom: a leading 'xcel' / 'cel' instead of 'Excel').
+    """
+    return tb % 4 == 0 and tb <= 0xAC
+
 def parse_identifiers(vba_project_stream: bytes) -> list[Identifier]:
     """Parse the ordered identifier table from a ``_VBA_PROJECT`` stream."""
     s = vba_project_stream
     n = len(s)
-    cands: list[tuple[int,int,str,int,int]] = []  # (start, end, name, id, type)
+    cands: list[tuple[int,int,str,int,int,int]] = []  # (start,end,name,id,type,desc)
     for p in range(n - 6):
         ln = s[p]
         if not (0 < ln < 64):
             continue
         tb = s[p+1]
+        if not _plausible_type(tb):
+            continue
         for desc in (0, 6):           # some types carry a 6-byte descriptor
             ns = p + 2 + desc
             ne = ns + ln
@@ -53,20 +65,33 @@ def parse_identifiers(vba_project_stream: bytes) -> list[Identifier]:
             if not _printable(nm):
                 continue
             cands.append((p, end, nm.decode("ascii"),
-                          int.from_bytes(s[ne:ne+2],"little"), tb))
-            break
+                          int.from_bytes(s[ne:ne+2],"little"), tb, desc))
     if not cands:
         return []
-    # Longest run of records that chain end->start, scanning greedily.
-    by_start = {c[0]: c for c in cands}
+    # Longest run of records that chain end->start.
+    #
+    # Tie-break matters: the 6-byte-descriptor variant can produce a
+    # false record that coincidentally aligns a few bytes before the
+    # real table start and yields a chain of equal length beginning
+    # mid-record (observed: a bogus leading 'cel' instead of 'Excel').
+    # Among equal-length chains prefer the one whose first record
+    # needs no descriptor, then the latest start -- the real table
+    # begins at a plain record.
+    by_start: dict[int, tuple] = {}
+    for c in cands:
+        # index by start; prefer the descriptor-free interpretation
+        if c[0] not in by_start or c[5] < by_start[c[0]][5]:
+            by_start[c[0]] = c
     best: list[tuple] = []
+    best_key = None
     for c in cands:
         chain=[c]; cur=c
         while cur[1] in by_start:
             cur = by_start[cur[1]]
             chain.append(cur)
-        if len(chain) > len(best):
-            best = chain
+        key = (len(chain), c[5] == 0, c[0])
+        if best_key is None or key > best_key:
+            best_key = key; best = chain
     return [Identifier(i, c[2], c[3], c[4], c[0]) for i, c in enumerate(best)]
 
 def resolve_name(operand: int, table: list[Identifier]) -> str | None:

--- a/docs/research/pcode/pcode_source.py
+++ b/docs/research/pcode/pcode_source.py
@@ -17,7 +17,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from pcode_decompile import find_decl_base, resolve_decl, resolve_type  # noqa: E402
+from pcode_decompile import (  # noqa: E402
+    find_decl_base, read_signature, resolve_decl, resolve_type,
+)
 from pcode_names import parse_identifiers, resolve_name  # noqa: E402
 from pyopenvba.vba_pcode import disassemble_module_stream  # noqa: E402
 
@@ -78,6 +80,24 @@ def decompile(module_stream: bytes, vba_project_stream: bytes,
                 return resolve_type(module_stream, v, dbase)
         return None
 
+    # Pair each FuncDefn with the End* that closes it, so Sub /
+    # Function / Property and the return type can be rendered.
+    flat = [i for l in dis.lines for i in l.instructions]
+    local_offsets = frozenset(
+        v for i in flat if i.mnemonic.startswith("VarDefn")
+        for a, v in i.operands if a == "var_"
+    )
+    proc_kind: dict[int, str] = {}
+    pending: list[int] = []
+    for i in flat:
+        if i.mnemonic in ("FuncDefn", "FuncDefnSave"):
+            for a, v in i.operands:
+                if a == "func_":
+                    pending.append(v)
+        elif i.mnemonic in ("EndSub", "EndFunc", "EndFunction", "EndProp"):
+            if pending:
+                proc_kind[pending.pop(0)] = i.mnemonic
+
     out: list[str] = []
     in_case = [False]
     indent = 1
@@ -101,7 +121,23 @@ def decompile(module_stream: bytes, vba_project_stream: bytes,
             m = op.mnemonic
 
             if m in ("FuncDefn", "FuncDefnSave"):
-                out.append(f"Sub {dname(op) or '<proc>'}()")
+                fo = next((v for a, v in op.operands if a == "func_"), None)
+                end = proc_kind.get(fo, "EndSub") if fo is not None else "EndSub"
+                kw = {"EndProp": "Property", "EndFunc": "Function",
+                      "EndFunction": "Function"}.get(end, "Sub")
+                if fo is not None:
+                    pname, params, ret = read_signature(
+                        module_stream, fo, dbase, ids,
+                        is_function=(kw != "Sub"),
+                        local_offsets=local_offsets)
+                else:
+                    pname, params, ret = None, [], None
+                arglist = ", ".join(
+                    f"{a} As {b}" if b else a for a, b in params)
+                sig = f"{kw} {pname or dname(op) or '<proc>'}({arglist})"
+                if ret and kw != "Sub":
+                    sig += f" As {ret}"
+                out.append(sig)
                 indent = 1
             elif m == "EndSub":
                 out.append("End Sub"); indent = 1

--- a/docs/research/pcode/pcode_source.py
+++ b/docs/research/pcode/pcode_source.py
@@ -1,0 +1,246 @@
+"""VBA source reconstruction from compiled p-code.
+
+P-code is a stack machine, so expressions reconstruct by simulation:
+``Ld b | Ld c | LitDI2 2 | Mul | Add | St a`` pops its way back to
+``a = b + c * 2``. Control-flow opcodes (``IfBlock``, ``For``,
+``DoWhile``, ``SelectCase``, ...) drive block structure and indentation.
+
+Host-agnostic: consumes only the module stream plus the project
+identifier table, both identical across Excel / Word / PowerPoint /
+Access.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pcode_decompile import find_decl_base, resolve_decl, resolve_type  # noqa: E402
+from pcode_names import parse_identifiers, resolve_name  # noqa: E402
+from pyopenvba.vba_pcode import disassemble_module_stream  # noqa: E402
+
+# opcode -> (VBA operator, precedence). Higher binds tighter.
+BINARY_OPS: dict[str, tuple[str, int]] = {
+    "Imp": ("Imp", 1), "Eqv": ("Eqv", 2), "Xor": ("Xor", 3),
+    "Or": ("Or", 4), "And": ("And", 5),
+    "Eq": ("=", 6), "Ne": ("<>", 6), "Lt": ("<", 6), "Gt": (">", 6),
+    "Le": ("<=", 6), "Ge": (">=", 6), "Is": ("Is", 6), "Like": ("Like", 6),
+    "Concat": ("&", 7),
+    "Add": ("+", 8), "Sub": ("-", 8),
+    "Mod": ("Mod", 9), "IDiv": ("\\", 10),
+    "Mul": ("*", 11), "Div": ("/", 11),
+    "Pwr": ("^", 13),
+}
+UNARY_OPS: dict[str, str] = {"Not": "Not ", "UMi": "-"}
+
+# Literal opcodes whose value is carried in operands or payload.
+_LIT_INT = {"LitDI2", "LitHI2", "LitDI4", "LitHI4", "LitDI8", "LitHI8",
+            "LitOI2", "LitOI4", "LitOI8"}
+
+
+class _Frame:
+    """One reconstructed statement's evaluation stack."""
+
+    def __init__(self) -> None:
+        self.stack: list[str] = []
+
+    def push(self, s: str) -> None:
+        self.stack.append(s)
+
+    def pop(self) -> str:
+        return self.stack.pop() if self.stack else "<?>"
+
+
+def decompile(module_stream: bytes, vba_project_stream: bytes,
+              *, is_64bit: bool = True) -> str:
+    """Reconstruct VBA source from a compiled module stream."""
+    ids = parse_identifiers(vba_project_stream)
+    dis = disassemble_module_stream(module_stream, is_64bit=is_64bit)
+    dbase = find_decl_base(module_stream, ids, is_64bit=is_64bit)
+
+    def nm(ins) -> str:
+        for a, v in ins.operands:
+            if a == "name":
+                return resolve_name(v, ids) or f"var{v:04X}"
+        return "<?>"
+
+    def dname(ins) -> str | None:
+        for a, v in ins.operands:
+            if a in ("func_", "var_"):
+                return resolve_decl(module_stream, v, dbase, ids)
+        return None
+
+    def dtype(ins) -> str | None:
+        for a, v in ins.operands:
+            if a == "var_":
+                return resolve_type(module_stream, v, dbase)
+        return None
+
+    out: list[str] = []
+    in_case = [False]
+    indent = 1
+    pending_for: list[str] = []          # for-variable names awaiting For
+
+    def emit(text: str, delta_before: int = 0, delta_after: int = 0) -> None:
+        nonlocal indent
+        indent = max(0, indent + delta_before)
+        out.append("    " * indent + text)
+        indent = max(0, indent + delta_after)
+
+    for line in dis.lines:
+        ins = list(line.instructions)
+        if not ins:
+            continue
+        f = _Frame()
+        stmt: str | None = None
+        i = 0
+        while i < len(ins):
+            op = ins[i]
+            m = op.mnemonic
+
+            if m in ("FuncDefn", "FuncDefnSave"):
+                out.append(f"Sub {dname(op) or '<proc>'}()")
+                indent = 1
+            elif m == "EndSub":
+                out.append("End Sub"); indent = 1
+            elif m in ("EndFunction", "EndFunc"):
+                out.append("End Function"); indent = 1
+            elif m == "EndProp":
+                out.append("End Property"); indent = 1
+            elif m == "Dim":
+                pass                       # handled by VarDefn below
+            elif m.startswith("VarDefn"):
+                vn = dname(op) or "<var>"
+                vt = dtype(op)
+                f.push(f"{vn} As {vt}" if vt else vn)
+            elif m == "Ld" or m == "LdLHS":
+                f.push(nm(op))
+            elif m in _LIT_INT:
+                vals = [v for a, v in op.operands]
+                f.push(str(vals[0] if vals else 0))
+            elif m == "LitStr":
+                f.push('"' + (op.payload or b"").decode("latin-1") + '"')
+            elif m == "LitNothing":
+                f.push("Nothing")
+            elif m == "LitDefault":
+                f.push("")
+            elif m == "LitVarSpecial":
+                f.push("Empty")
+            elif m in BINARY_OPS:
+                sym, _ = BINARY_OPS[m]
+                rhs = f.pop(); lhs = f.pop()
+                joiner = f" {sym} " if sym.isalpha() or len(sym) > 1 else f" {sym} "
+                f.push(f"{lhs}{joiner}{rhs}")
+            elif m in UNARY_OPS:
+                f.push(UNARY_OPS[m] + f.pop())
+            elif m == "Paren":
+                f.push("(" + f.pop() + ")")
+            elif m in ("St", "SetOrSt"):
+                stmt = f"{nm(op)} = {f.pop()}"
+            elif m == "SetStmt":
+                rhs = f.pop(); lhs = f.pop() if f.stack else "<?>"
+                stmt = f"Set {lhs} = {rhs}"
+            elif m in ("ArgsCall", "ArgsMemCall", "ArgsMemCallWith"):
+                argc = 0
+                for a, v in op.operands:
+                    if a == "0x":
+                        argc = v
+                args = [f.pop() for _ in range(min(argc, len(f.stack)))][::-1]
+                callee = nm(op)
+                call = f"{callee}({', '.join(args)})" if args else callee
+                # statement position if nothing consumes it
+                if i == len(ins) - 1:
+                    stmt = f"{callee} {', '.join(args)}".rstrip() if args else callee
+                else:
+                    f.push(call)
+            elif m in ("ArgsLd", "ArgsMemLd", "IndexLd"):
+                argc = 0
+                for a, v in op.operands:
+                    if a == "0x":
+                        argc = v
+                args = [f.pop() for _ in range(min(argc, len(f.stack)))][::-1]
+                base = nm(op) if m != "IndexLd" else f.pop()
+                f.push(f"{base}({', '.join(args)})")
+            elif m == "StartForVariable":
+                pass
+            elif m == "EndForVariable":
+                pending_for.append(f.pop())
+            elif m in ("For", "ForStep"):
+                step = f.pop() if m == "ForStep" else None
+                to = f.pop(); frm = f.pop()
+                var = pending_for.pop() if pending_for else "<i>"
+                text = f"For {var} = {frm} To {to}"
+                if step is not None:
+                    text += f" Step {step}"
+                emit(text, 0, 1); stmt = None
+            elif m in ("Next", "NextVar"):
+                var = pending_for.pop() if pending_for else ""
+                emit(f"Next {var}".rstrip(), -1, 0)
+            elif m == "IfBlock":
+                emit(f"If {f.pop()} Then", 0, 1)
+            elif m == "ElseIfBlock":
+                emit(f"ElseIf {f.pop()} Then", -1, 1)
+            elif m == "ElseBlock":
+                emit("Else", -1, 1)
+            elif m == "EndIfBlock":
+                emit("End If", -1, 0)
+            elif m == "If":
+                stmt = f"If {f.pop()} Then"
+            elif m in ("DoWhile", "While"):
+                kw = "Do While" if m == "DoWhile" else "While"
+                emit(f"{kw} {f.pop()}", 0, 1)
+            elif m == "DoUntil":
+                emit(f"Do Until {f.pop()}", 0, 1)
+            elif m == "Do":
+                emit("Do", 0, 1)
+            elif m == "Loop":
+                emit("Loop", -1, 0)
+            elif m == "LoopWhile":
+                emit(f"Loop While {f.pop()}", -1, 0)
+            elif m == "LoopUntil":
+                emit(f"Loop Until {f.pop()}", -1, 0)
+            elif m == "Wend":
+                emit("Wend", -1, 0)
+            elif m == "SelectCase":
+                emit(f"Select Case {f.pop()}", 0, 1)
+                in_case[0] = False
+            elif m == "Case":
+                pass
+            elif m == "CaseEq":
+                f.push(f.pop())
+            elif m == "CaseDone":
+                vals = list(f.stack); f.stack.clear()
+                emit("Case " + ", ".join(vals), -1 if in_case[0] else 0, 1)
+                in_case[0] = True
+            elif m == "CaseElse":
+                emit("Case Else", -1 if in_case[0] else 0, 1)
+                in_case[0] = True
+            elif m == "EndSelect":
+                emit("End Select", -2 if in_case[0] else -1, 0)
+                in_case[0] = False
+            elif m in ("ExitSub", "ExitFunc", "ExitFor", "ExitDo"):
+                stmt = {"ExitSub": "Exit Sub", "ExitFunc": "Exit Function",
+                        "ExitFor": "Exit For", "ExitDo": "Exit Do"}[m]
+            elif m in ("QuoteRem", "Rem"):
+                stmt = "'" + (op.payload or b"").decode("latin-1")
+            elif m in ("BoS", "BoSImplicit", "BoL", "Coerce", "CoerceVar",
+                       "LitSmallI2", "EndContext", "Context", "Option",
+                       "OptionBase", "DimImplicit", "NewRedim"):
+                pass
+            else:
+                stmt = f"' [unmapped {m}]"
+            i += 1
+
+        if stmt is None and f.stack and not any(
+            x.mnemonic in ("Dim",) for x in ins
+        ):
+            leftover = " ".join(f.stack)
+            if leftover.strip():
+                stmt = leftover
+        if any(x.mnemonic == "Dim" for x in ins):
+            stmt = "Dim " + ", ".join(f.stack) if f.stack else None
+        if stmt:
+            emit(stmt)
+    return "\n".join(out)


### PR DESCRIPTION
Documentation and research only: `src/` is byte-identical to `main`, the public API is unchanged, and nothing here is imported by the shipped library. pyOpenVBA stays pure-Python with no Office dependency.

## What this adds

`docs/pcode_reference.md` — a field guide to the compiled VBA7 p-code format, reverse-engineered against real Office-compiled modules, plus the prototypes backing it in `docs/research/pcode/`.

The format is **host-agnostic**: Excel, Word, PowerPoint and Access embed the same structures and the same `CC 61` identifier table, differing only in the container (CFB streams vs Access LVAL rows) and the 32/64-bit opcode remap. So a reader/writer is written once and works everywhere.

## Format findings

Documented with worked examples, each verified against Office's own compiler:

- **Name operands**: `operand = 0x20E + 2 * identifier_index` into the project table (not the record's id cookie).
- **The second operand space**: operands below `0x20E` address a fixed, alphabetically-ordered table of built-in names held by the VBA *runtime*, not stored in the file. A user name that collides with a built-in reuses its operand — which is why `Dim b` and `Dim f` never reach the project table.
- **Declaration operands**: `func_`/`var_` are offsets from a per-module `DECL_BASE` to a u16 that is itself a name operand.
- **Declared types**: a VARTYPE byte at `DECL_BASE + var_operand + 14`. 12/12 verified.
- **Procedure signatures**: name at the `func_` offset, parameters at `+0x58` in `0x20` strides, return type as a repeated name entry with a type.

## Results

**Assembler** (byte-exact against Office output): instruction encoder 278/278 across 19/20 fixtures; full CAFE-region regeneration exact on a 230-line / 20,960-byte module; same-length and variable-length edits with line-table reflow.

**Decompiler**: p-code is a stack machine, so expressions rebuild by simulating it, and control flow is explicit enough to recover block structure and indentation.

- **11/11 exact** round-trip on a compiled corpus, normalising only for what p-code genuinely does not encode (the optional `Call` keyword, `ByVal`/`ByRef`, `$` suffixes, and casing for built-in collisions).
- **54/54 modules** across every committed Office fixture decompile with no unmapped opcodes, including a 230-line real-world module.

## Verification

Excel is used as the reference implementation via a compile oracle — pyOpenVBA writes source, Excel compiles and saves, pyOpenVBA reads the compiled bytes back — driven by the hang-safe `pyvbaharness`. That is a development tool only and introduces no runtime dependency.

## Open items, labelled as such

The identifier hash function (the real gate on writing *new* identifiers), the full contents of the runtime built-in table, the `0x20E` derivation, where `DECL_BASE` lives, `Optional` parameter slots, distinguishing `Property Get`/`Let`/`Set`, and a full source-to-p-code compiler.
